### PR TITLE
[2/6] fix(security): cap request bodies while streaming, stop leaking auth headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,7 @@ PORT=8080
 
 # Logging level: trace, debug, info, warn, error (default: info)
 RUST_LOG=info
+# Maximum request body size Mimic will buffer, in bytes (default: 10485760 = 10 MB)
+# Requests over this size are rejected with 413 Payload Too Large before the
+# body is buffered.
+MIMIC_MAX_BODY_SIZE=10485760

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "axum",
  "bytes",
  "chrono",
+ "http-body",
  "http-body-util",
  "rand",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rand = "0.10"
 
 [dev-dependencies]
 tempfile = "3"
+http-body = "1"
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1.4"
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ PORT=8080
 
 # Logging level: trace, debug, info, warn, error (default: info)
 RUST_LOG=info
+
+# Maximum request body Mimic will buffer, in bytes (default: 10485760 = 10 MB)
+MIMIC_MAX_BODY_SIZE=10485760
 ```
 
 **Log Levels**:
@@ -812,6 +815,13 @@ Mock responses don't have to be fully static. Use `{{ }}` double-brace syntax in
 | `{{body.user.email}}` | Nested JSON body field (dot notation) |
 | `{{path.id}}` | Named [path parameter](#path-parameters) `:id` or `{id}` |
 
+> **Credential headers are never echoed.** `{{header.authorization}}`,
+> `{{header.cookie}}` and `{{header.set-cookie}}` always render as an empty
+> string — the same as a missing key — regardless of letter case. This matches
+> the redaction already applied to the `/admin/requests` log, so a mock file
+> can't reflect a live bearer token or session cookie into a response body
+> (and from there into browser devtools, HAR exports, or CI logs).
+
 ### Example
 
 ```json
@@ -1104,6 +1114,34 @@ curl -X POST http://localhost:8080/ocr-image \
 # Works with consume_body: false (default)
 curl -X POST http://localhost:8080/trigger-job
 ```
+
+### Maximum Body Size
+
+Request bodies are capped at **10 MB** by default. The cap is enforced *while
+the body streams in*, so an oversized request is turned away before Mimic
+allocates memory for it — a client cannot drive the server's memory use past
+the limit no matter how much it sends.
+
+Over-limit requests get a `413 Payload Too Large`:
+
+```json
+{
+  "error": "payload too large",
+  "method": "POST",
+  "path": "/upload",
+  "max_body_size": 10485760
+}
+```
+
+Raise or lower the cap with the `MIMIC_MAX_BODY_SIZE` environment variable
+(in bytes):
+
+```bash
+MIMIC_MAX_BODY_SIZE=52428800 mimic   # 50 MB
+```
+
+An unset, unparsable, or zero value falls back to the 10 MB default. The
+active limit is printed at startup.
 
 ---
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -2,7 +2,9 @@ use crate::matcher::{
     find_matching_mock, parse_body, parse_headers, parse_query_string, MatchResult, RequestContext,
 };
 use crate::template::{render_response, TemplateContext};
-use crate::types::{MockStore, RequestLog, RequestRecord, SequenceCounters, SequenceStep};
+use crate::types::{
+    is_sensitive_header, MockStore, RequestLog, RequestRecord, SequenceCounters, SequenceStep,
+};
 use axum::{
     body::Body,
     extract::{Query, State},
@@ -11,7 +13,7 @@ use axum::{
 };
 use bytes::Bytes;
 use chrono::Utc;
-use http_body_util::BodyExt;
+use http_body_util::{BodyExt, LengthLimitError, Limited};
 use serde::Deserialize;
 use serde_json::json;
 use std::collections::HashMap;
@@ -38,8 +40,34 @@ impl AppState {
     }
 }
 
-/// Maximum body size to consume for matching (10 MB)
-const MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
+/// Default cap on the request body Mimic will buffer (10 MB).
+const DEFAULT_MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
+
+/// Environment variable overriding [`DEFAULT_MAX_BODY_SIZE`], in bytes.
+const MAX_BODY_SIZE_ENV: &str = "MIMIC_MAX_BODY_SIZE";
+
+/// The configured maximum request body size, in bytes.
+///
+/// Read once from `MIMIC_MAX_BODY_SIZE` on first use; an unset, unparsable,
+/// or zero value falls back to [`DEFAULT_MAX_BODY_SIZE`]. The limit is
+/// enforced *while* the body streams in (see [`handle_request`]), so a
+/// request larger than this never gets fully buffered.
+pub fn max_body_size() -> usize {
+    static MAX: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *MAX.get_or_init(|| match std::env::var(MAX_BODY_SIZE_ENV) {
+        Ok(raw) => match raw.trim().parse::<usize>() {
+            Ok(n) if n > 0 => n,
+            _ => {
+                warn!(
+                    "Invalid {}='{}', falling back to {} bytes",
+                    MAX_BODY_SIZE_ENV, raw, DEFAULT_MAX_BODY_SIZE
+                );
+                DEFAULT_MAX_BODY_SIZE
+            }
+        },
+        Err(_) => DEFAULT_MAX_BODY_SIZE,
+    })
+}
 
 pub async fn handle_request(
     method: Method,
@@ -71,23 +99,26 @@ pub async fn handle_request(
         mocks.values().flatten().any(|mock| mock.body.is_some())
     };
 
-    // Consume body if needed for matching or if consume_body is set
+    // Consume body if needed for matching or if consume_body is set.
+    //
+    // The body is wrapped in `Limited` so the stream is cut off — and the
+    // request rejected with 413 — as soon as it exceeds the cap, rather than
+    // being buffered in full and only then measured.
+    let max_body = max_body_size();
     let body_bytes: Option<Bytes> =
         if needs_body_matching || matches!(method, Method::POST | Method::PUT | Method::PATCH) {
-            match body.collect().await {
+            match Limited::new(body, max_body).collect().await {
                 Ok(collected) => {
                     let bytes = collected.to_bytes();
-                    if bytes.len() > MAX_BODY_SIZE {
-                        debug!(
-                            "Body too large: {} bytes (max: {})",
-                            bytes.len(),
-                            MAX_BODY_SIZE
-                        );
-                        None
-                    } else {
-                        debug!("Consumed {} bytes from request body", bytes.len());
-                        Some(bytes)
-                    }
+                    debug!("Consumed {} bytes from request body", bytes.len());
+                    Some(bytes)
+                }
+                Err(e) if is_length_limit(&*e) => {
+                    warn!(
+                        "Rejecting {} {}: request body exceeds the {}-byte limit",
+                        method_str, path, max_body
+                    );
+                    return payload_too_large(&method_str, &path, max_body);
                 }
                 Err(e) => {
                     debug!("Failed to read body: {}", e);
@@ -200,6 +231,39 @@ pub async fn handle_request(
     }
 }
 
+/// True if `err`, or anything it wraps, is a body-length-limit error.
+///
+/// The source chain has to be walked rather than downcasting the outermost
+/// error: the limit trips deep inside the body stream and surfaces re-boxed,
+/// so a plain downcast only sees the outer layer — which is how an oversized
+/// chunked body could be mistaken for "no body" and answered 200.
+fn is_length_limit(err: &(dyn std::error::Error + 'static)) -> bool {
+    let mut current = Some(err);
+    while let Some(e) = current {
+        if e.is::<LengthLimitError>() {
+            return true;
+        }
+        current = e.source();
+    }
+    false
+}
+
+/// 413 returned when a request body exceeds [`max_body_size`]. Mirrors the
+/// shape of the 404 "mock not found" body so clients can parse either the
+/// same way.
+fn payload_too_large(method: &str, path: &str, max_body: usize) -> Response {
+    (
+        StatusCode::PAYLOAD_TOO_LARGE,
+        Json(json!({
+            "error": "payload too large",
+            "method": method,
+            "path": path,
+            "max_body_size": max_body
+        })),
+    )
+        .into_response()
+}
+
 pub async fn health_check(State(state): State<AppState>) -> Json<serde_json::Value> {
     let mocks = state.mocks.read().await;
     Json(json!({
@@ -208,9 +272,6 @@ pub async fn health_check(State(state): State<AppState>) -> Json<serde_json::Val
         "service": "mimic"
     }))
 }
-
-/// Headers whose values should be redacted in recorded requests
-const SENSITIVE_HEADERS: &[&str] = &["authorization", "cookie", "set-cookie"];
 
 /// Record a request into the request log, redacting sensitive headers
 async fn record_request(
@@ -223,7 +284,7 @@ async fn record_request(
         .headers
         .into_iter()
         .map(|(k, v)| {
-            if SENSITIVE_HEADERS.contains(&k.as_str()) {
+            if is_sensitive_header(&k) {
                 (k, "[REDACTED]".to_string())
             } else {
                 (k, v)
@@ -2225,5 +2286,113 @@ mod tests {
         let (status, headers, _) = call_raw(&state, "/seq").await;
         assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
         assert_eq!(headers.get("retry-after").unwrap(), "60");
+    }
+    #[tokio::test]
+    async fn test_oversized_body_rejected_with_413() {
+        let state = create_test_state();
+        let max = max_body_size();
+
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "application/json".parse().unwrap());
+
+        let response = handle_request(
+            Method::POST,
+            "/echo".parse().unwrap(),
+            headers,
+            State(state),
+            Body::from(vec![b'x'; max + 1]),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["error"], "payload too large");
+        assert_eq!(json["max_body_size"], max);
+    }
+
+    #[tokio::test]
+    async fn test_body_at_the_limit_is_still_accepted() {
+        let state = create_test_state();
+        let max = max_body_size();
+
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "text/plain".parse().unwrap());
+
+        let response = handle_request(
+            Method::POST,
+            "/echo".parse().unwrap(),
+            headers,
+            State(state),
+            Body::from(vec![b'x'; max]),
+        )
+        .await;
+
+        // No mock matches /echo, but the body itself was accepted rather than
+        // rejected as oversized.
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_oversized_streaming_body_is_not_fully_buffered() {
+        let state = create_test_state();
+        let max = max_body_size();
+        let chunk_size = 64 * 1024;
+
+        // A chunked body with no Content-Length that would keep producing far
+        // more than the limit. `Limited` must stop polling it once the cap is
+        // crossed, so `delivered` never approaches the full (10x limit) size.
+        let delivered = Arc::new(AtomicU64::new(0));
+        let body = Body::new(EndlessBody {
+            delivered: delivered.clone(),
+            chunk_size,
+            total: max * 10,
+        });
+
+        let response = handle_request(
+            Method::POST,
+            "/echo".parse().unwrap(),
+            HeaderMap::new(),
+            State(state),
+            body,
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let read = delivered.load(Ordering::Relaxed) as usize;
+        assert!(
+            read <= max + chunk_size,
+            "read {} bytes for a {}-byte limit; the body was buffered past the cap",
+            read,
+            max
+        );
+    }
+
+    /// A Content-Length-less body that yields `chunk_size` chunks until
+    /// `total` bytes have been handed out, counting everything it emits.
+    struct EndlessBody {
+        delivered: Arc<AtomicU64>,
+        chunk_size: usize,
+        total: usize,
+    }
+
+    impl http_body::Body for EndlessBody {
+        type Data = Bytes;
+        type Error = std::convert::Infallible;
+
+        fn poll_frame(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Result<http_body::Frame<Bytes>, Self::Error>>> {
+            if self.delivered.load(Ordering::Relaxed) as usize >= self.total {
+                return std::task::Poll::Ready(None);
+            }
+            self.delivered
+                .fetch_add(self.chunk_size as u64, Ordering::Relaxed);
+            std::task::Poll::Ready(Some(Ok(http_body::Frame::data(Bytes::from(vec![
+                    b'x';
+                    self.chunk_size
+                ])))))
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,8 @@ use axum::{
     Router,
 };
 use handler::{
-    admin_dashboard, clear_requests, handle_request, health_check, list_requests, reset_sequences,
-    AppState,
+    admin_dashboard, clear_requests, handle_request, health_check, list_requests, max_body_size,
+    reset_sequences, AppState,
 };
 use loader::{load_mocks, load_mocks_map};
 use std::env;
@@ -41,6 +41,7 @@ async fn main() {
     info!("Configuration:");
     info!("  Mocks directory: {}", MOCKS_DIR);
     info!("  Port: {}", port);
+    info!("  Max request body: {} bytes", max_body_size());
 
     // Load mock configurations
     let mocks = load_mocks(MOCKS_DIR);
@@ -133,6 +134,13 @@ fn create_router(state: AppState) -> Router {
         // Add state
         .with_state(state)
         // Add tracing middleware
+        //
+        // The request-body cap is enforced in `handle_request` rather than by
+        // a `tower_http` `RequestBodyLimitLayer` here: the layer's rejection
+        // carries a plain-text body, which would answer the same condition two
+        // different ways depending on whether the client declared a
+        // Content-Length. `Limited` in the handler caps the stream just as
+        // hard and always returns the documented JSON shape.
         .layer(TraceLayer::new_for_http())
 }
 
@@ -304,5 +312,71 @@ mod tests {
         let bytes = response.into_body().collect().await.unwrap().to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(json["reset"], 0);
+    }
+
+    // ------------------------------------------------------------------
+    // Body limit through the full router (#50)
+    // ------------------------------------------------------------------
+
+    /// A Content-Length-less body that keeps producing chunks, so the limit
+    /// has to be enforced mid-stream rather than from a declared size.
+    struct ChunkedBody {
+        remaining: usize,
+    }
+
+    impl http_body::Body for ChunkedBody {
+        type Data = bytes::Bytes;
+        type Error = std::convert::Infallible;
+
+        fn poll_frame(
+            mut self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Result<http_body::Frame<bytes::Bytes>, Self::Error>>> {
+            if self.remaining == 0 {
+                return std::task::Poll::Ready(None);
+            }
+            let chunk = 64 * 1024;
+            self.remaining = self.remaining.saturating_sub(chunk);
+            std::task::Poll::Ready(Some(Ok(http_body::Frame::data(bytes::Bytes::from(vec![
+                    b'x';
+                    chunk
+                ])))))
+        }
+    }
+
+    /// Both shapes must produce the same documented JSON body, not one JSON
+    /// and one plain-text rejection.
+    async fn assert_413_json(body: Body) {
+        let app = create_router(test_state());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/upload")
+                    .header("content-type", "text/plain")
+                    .body(body)
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["error"], "payload too large");
+        assert_eq!(json["max_body_size"], handler::max_body_size());
+    }
+
+    #[tokio::test]
+    async fn test_router_rejects_oversized_sized_body_with_413() {
+        assert_413_json(Body::from(vec![b'x'; handler::max_body_size() + 1])).await;
+    }
+
+    #[tokio::test]
+    async fn test_router_rejects_oversized_chunked_body_with_413() {
+        assert_413_json(Body::new(ChunkedBody {
+            remaining: handler::max_body_size() * 2,
+        }))
+        .await;
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -3,10 +3,12 @@
 //! query params, headers, and the request body).
 
 use crate::matcher::ParsedBody;
+use crate::types::is_sensitive_header;
 use regex::Regex;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::OnceLock;
+use tracing::debug;
 
 /// Data available to templates, sourced from the matched request.
 pub struct TemplateContext<'a> {
@@ -72,7 +74,19 @@ fn resolve(source: &str, key: &str, ctx: &TemplateContext) -> Option<String> {
     match source {
         "path" => ctx.path_params.get(key).cloned(),
         "query" => ctx.query_params.get(key).cloned(),
-        "header" => ctx.headers.get(&key.to_lowercase()).cloned(),
+        // Credential-bearing headers are never interpolated: echoing a live
+        // bearer token or session cookie back into a response body would put
+        // it in devtools, HAR exports and CI logs. They resolve like a
+        // missing key does — to an empty string.
+        "header" => {
+            let name = key.to_lowercase();
+            if is_sensitive_header(&name) {
+                debug!("Refusing to interpolate sensitive header '{}'", name);
+                None
+            } else {
+                ctx.headers.get(&name).cloned()
+            }
+        }
         "body" => resolve_body(ctx.body, key),
         _ => None,
     }
@@ -293,5 +307,51 @@ mod tests {
 
         let value = json!({"x": "{{cookie.session}}"});
         assert_eq!(render_response(&value, &c), json!({"x": ""}));
+    }
+
+    #[test]
+    fn test_sensitive_headers_are_never_interpolated() {
+        let mut headers = HashMap::new();
+        headers.insert(
+            "authorization".to_string(),
+            "Bearer sk_live_secret".to_string(),
+        );
+        headers.insert("cookie".to_string(), "session=abc123".to_string());
+        headers.insert("set-cookie".to_string(), "session=abc123".to_string());
+        let empty = HashMap::new();
+        let c = ctx(&empty, &empty, &headers, None);
+
+        let value = json!({
+            "auth": "{{header.authorization}}",
+            "cookie": "{{header.cookie}}",
+            "set_cookie": "{{header.set-cookie}}"
+        });
+        assert_eq!(
+            render_response(&value, &c),
+            json!({"auth": "", "cookie": "", "set_cookie": ""})
+        );
+    }
+
+    #[test]
+    fn test_sensitive_header_redaction_is_case_insensitive() {
+        let mut headers = HashMap::new();
+        headers.insert("authorization".to_string(), "Bearer secret".to_string());
+        let empty = HashMap::new();
+        let c = ctx(&empty, &empty, &headers, None);
+
+        let value = json!({"a": "{{header.Authorization}}", "b": "{{header.AUTHORIZATION}}"});
+        assert_eq!(render_response(&value, &c), json!({"a": "", "b": ""}));
+    }
+
+    #[test]
+    fn test_non_sensitive_headers_still_interpolate() {
+        let mut headers = HashMap::new();
+        headers.insert("authorization".to_string(), "Bearer secret".to_string());
+        headers.insert("x-tenant".to_string(), "acme".to_string());
+        let empty = HashMap::new();
+        let c = ctx(&empty, &empty, &headers, None);
+
+        let value = json!({"tenant": "{{header.x-tenant}}"});
+        assert_eq!(render_response(&value, &c), json!({"tenant": "acme"}));
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,25 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 // ============================================================================
+// Sensitive Header Handling
+// ============================================================================
+
+/// Headers whose values must never leave the process — neither stored in the
+/// request log nor interpolated into a mock response by templating.
+///
+/// Defined here (rather than in one consumer) so `handler.rs` and
+/// `template.rs` can't drift apart on what counts as a secret.
+pub const SENSITIVE_HEADERS: &[&str] = &["authorization", "cookie", "set-cookie"];
+
+/// True if `name` names a header carrying credentials. Case-insensitive, so
+/// it works on both already-normalized and raw header names.
+pub fn is_sensitive_header(name: &str) -> bool {
+    SENSITIVE_HEADERS
+        .iter()
+        .any(|sensitive| name.eq_ignore_ascii_case(sensitive))
+}
+
+// ============================================================================
 // Query Parameter Matching Types
 // ============================================================================
 


### PR DESCRIPTION
**Stack position: 2 of 6** — based on #68. Merge the roll-up PR to take all six at once.

Closes #50
Closes #51

## #50 — Unbounded request-body buffering allowed memory-exhaustion DoS

`handle_request` called `body.collect()` and only *then* compared the result against `MAX_BODY_SIZE`. The whole allocation had already happened by the time the check ran, so a 200 MB upload produced a 200 MB spike before being discarded — against a project whose pitch is "only 1.66 MiB memory usage".

The body is now wrapped in `http_body_util::Limited`, which stops polling the stream the moment the cap is crossed. Oversized requests get `413 Payload Too Large` instead of being silently treated as bodyless.

**Detecting the condition walks the error's source chain** rather than downcasting the outermost error. The limit trips deep inside the body stream and surfaces re-boxed; a plain downcast misses it, which let an oversized *chunked* body (no `Content-Length`) through as "no body" and answer `200`. This was found by smoke-testing the running server, not by the unit tests — there's now a router-level test for both shapes.

`tower_http::limit::RequestBodyLimitLayer` was considered and deliberately not used: its rejection carries a plain-text body, so the same condition would be answered two different ways depending on whether the client declared a `Content-Length`. `Limited` in the handler caps the stream just as hard and always returns the documented JSON shape.

The limit is no longer hardcoded — `MIMIC_MAX_BODY_SIZE` (bytes) overrides the 10 MB default, is validated once on first use, and is logged at startup.

```json
{ "error": "payload too large", "method": "POST", "path": "/upload", "max_body_size": 10485760 }
```

## #51 — Response templating could leak Authorization/Cookie values

`{{header.authorization}}`, `{{header.cookie}}` and `{{header.set-cookie}}` resolved straight out of the parsed request headers — while `record_request` had been redacting exactly those three since it was written. Same secret-handling policy, two code paths, one of them missing it.

`SENSITIVE_HEADERS` and `is_sensitive_header()` now live once in `types.rs` and are consulted by both, so the lists can't drift. Sensitive headers render as an empty string, matching missing-key behavior, in any letter case.

```console
$ curl -H "Authorization: Bearer sk_live_secret" -H "X-Tenant: acme" localhost:8080/whoami
{"echo_auth":"","echo_cookie":"","tenant":"acme"}
```

## Behavior change

Requests over the limit now get `413` where they previously got whatever the mock set would have returned for a bodyless request (often `200` or `404`). This is the intended fix, but it is a status-code change for any client currently sending oversized bodies.

## Tests

- oversized fixed-length body → 413
- body exactly at the limit → still accepted
- `Content-Length`-less stream is cut off within one chunk of the cap rather than buffered whole (asserts on bytes actually pulled from the stream, not on timing)
- both sized and chunked shapes return the same JSON 413 through the full router
- sensitive headers never interpolate in any letter case; ordinary headers still do

## Verification

`cargo test` (172 passing), `clippy -- -D warnings`, `fmt --check` clean. Verified against a running server with a 1 MB limit: sized and chunked oversized bodies both return the JSON 413; a 1 KB body returns 200.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7GhL45q8B6tjLEVNsMbyw)_