### PR TITLE
[3/6] perf(matcher): compile every mock-file regex once instead of per request

### DIFF
--- a/ADVANCED_MATCHING.md
+++ b/ADVANCED_MATCHING.md
@@ -459,9 +459,30 @@ This shows what the server received, helping you debug mismatches.
 ## Performance Notes
 
 - Mocks without advanced matchers use fast path (simple lookup)
-- Advanced matching adds minimal overhead (~1-5ms)
 - Body matching requires consuming the request body
 - Use `strict: false` for better matching flexibility
+
+### Regex and path-template compilation
+
+Every regex Mimic derives from a mock file — `query_params` regex, `headers`
+regex, body `text.regex`, and `:id`/`{id}` path templates — is compiled **once
+per distinct pattern string** for the lifetime of the process and reused from
+then on. Hot reload does not invalidate the cache, because it is keyed by the
+pattern string itself. Invalid patterns are reported once, not once per
+request.
+
+Measured on a release build (`cargo test --release -- --ignored --nocapture`,
+see `mod benches` in `src/matcher.rs`); figures are per request:
+
+| Operation | Recompiling each request | Compiled once |
+|---|---|---|
+| One header regex matcher (`^[A-Za-z0-9]{32}$`) | ~46 µs | ~0.16 µs |
+| Exact-path request, 20 path-template routes loaded | ~6.0 ms | ~0.3 µs |
+| Path-parameter request, 20 path-template routes loaded | ~6.0 ms | ~7 µs |
+
+The exact-path row is the largest win and comes from two changes together: the
+pattern scan is skipped entirely when the exact lookup already matched, and
+templates that *are* scanned are no longer recompiled per request.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Multiple parameters, and nested resources, work the same way:
 **Semantics:**
 - Captured values are available for [response templating](#-dynamic-response-templating) as `{{path.id}}`.
 - An **exact path always wins over a pattern** when both could match — e.g. if `/users/42` and `/users/:id` are both defined, a request for `/users/42` hits the exact mock and everything else falls through to the pattern.
-- Exact-path lookups stay O(1); patterns are only checked when no exact match exists, so mocks with no path parameters see no performance change.
+- Exact-path lookups stay O(1); the pattern scan only runs when the exact lookup matched nothing, so mocks with no path parameters see no performance change. Each path template is compiled to a regex once per process and reused, never recompiled per request.
 - A [sequence](#-stateful-response-sequences) on a pattern mock advances a single shared counter across every value of the parameter (e.g. `/items/1` and `/items/2` progress the same sequence for `/items/:id`), not one counter per resolved id.
 
 ### Query Parameter Matching

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod handler;
 mod loader;
 mod matcher;
+mod regex_cache;
 mod template;
 mod types;
 

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -5,6 +5,7 @@
 //! - HTTP headers
 //! - Request body (JSON, text, form)
 
+use crate::regex_cache::{cached, compiled_regex, CompileCache};
 use crate::types::{
     BodyMatcher, FormBodyMatcher, HeaderMatcher, HeaderPattern, HeaderValue, JsonBodyMatcher,
     MockConfig, QueryParamMatcher, QueryParamPattern, QueryParamValue, TextBodyMatcher,
@@ -12,6 +13,7 @@ use crate::types::{
 use bytes::Bytes;
 use regex::Regex;
 use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
 use tracing::{debug, warn};
 
 // ============================================================================
@@ -121,12 +123,9 @@ fn match_query_param_value(actual: &str, expected: &QueryParamValue) -> bool {
     match expected {
         QueryParamValue::Exact(value) => actual == value,
         QueryParamValue::Pattern(pattern) => match pattern {
-            QueryParamPattern::Regex(regex_str) => match Regex::new(regex_str) {
-                Ok(re) => re.is_match(actual),
-                Err(e) => {
-                    warn!("Invalid regex pattern '{}': {}", regex_str, e);
-                    false
-                }
+            QueryParamPattern::Regex(regex_str) => match compiled_regex(regex_str) {
+                Some(re) => re.is_match(actual),
+                None => false,
             },
             QueryParamPattern::Any => true,
         },
@@ -220,12 +219,9 @@ fn match_header_value(actual: &str, expected: &HeaderValue) -> bool {
     match expected {
         HeaderValue::Exact(value) => actual == value,
         HeaderValue::Pattern(pattern) => match pattern {
-            HeaderPattern::Regex(regex_str) => match Regex::new(regex_str) {
-                Ok(re) => re.is_match(actual),
-                Err(e) => {
-                    warn!("Invalid regex pattern '{}': {}", regex_str, e);
-                    false
-                }
+            HeaderPattern::Regex(regex_str) => match compiled_regex(regex_str) {
+                Some(re) => re.is_match(actual),
+                None => false,
             },
             HeaderPattern::Any => true,
             HeaderPattern::Prefix(prefix) => actual.starts_with(prefix),
@@ -458,17 +454,14 @@ fn match_text_body(actual: &str, matcher: &TextBodyMatcher) -> bool {
 
     // Regex
     if let Some(ref pattern) = matcher.regex {
-        match Regex::new(pattern) {
-            Ok(re) => {
+        match compiled_regex(pattern) {
+            Some(re) => {
                 if !re.is_match(actual) {
                     debug!("Text does not match regex '{}'", pattern);
                     return false;
                 }
             }
-            Err(e) => {
-                warn!("Invalid regex pattern '{}': {}", pattern, e);
-                return false;
-            }
+            None => return false,
         }
     }
 
@@ -530,6 +523,26 @@ pub fn is_pattern_path(path: &str) -> bool {
     })
 }
 
+/// Compile (or reuse) the pattern for `path`.
+///
+/// Path templates come from mock files, so the same handful of strings are
+/// matched against on every request. Compiling them is memoized process-wide:
+/// a given template costs one `Regex::new` for the lifetime of the process,
+/// not one per request. Hot reload swapping the mock map doesn't invalidate
+/// anything — the cache is keyed by the template string itself.
+pub fn compile_path_pattern(path: &str) -> Option<Arc<CompiledPathPattern>> {
+    cached(&PATH_PATTERN_CACHE, path, build_path_pattern)
+}
+
+static PATH_PATTERN_CACHE: CompileCache<CompiledPathPattern> = OnceLock::new();
+
+/// True if `path` has ever been compiled in this process. Test-only probe for
+/// asserting that a request never reached the path-pattern compiler.
+#[cfg(test)]
+pub fn path_pattern_is_cached(path: &str) -> bool {
+    crate::regex_cache::is_cached(&PATH_PATTERN_CACHE, path)
+}
+
 /// Compile a path template into a regex with one (unnamed, positional)
 /// capture group per parameter segment — using positional groups rather
 /// than Rust regex's named-group syntax means parameter names aren't
@@ -537,7 +550,7 @@ pub fn is_pattern_path(path: &str) -> bool {
 ///
 /// Returns `None` if the path has no parameter segments, or the resulting
 /// regex fails to compile.
-pub fn compile_path_pattern(path: &str) -> Option<CompiledPathPattern> {
+fn build_path_pattern(path: &str) -> Option<CompiledPathPattern> {
     let mut param_names = Vec::new();
     let mut regex_parts = Vec::new();
 
@@ -608,10 +621,11 @@ pub struct MatchResult {
 
 /// Find the best matching mock for a request.
 ///
-/// Exact "METHOD:path" lookups are O(1) and tried first; parameterized
-/// paths (`:id`, `{id}`) are only checked afterward, by scanning mocks
-/// registered under the same method, and always score lower — so an exact
-/// path match wins over a pattern match whenever both are eligible.
+/// Exact "METHOD:path" lookups are O(1) and tried first. Parameterized paths
+/// (`:id`, `{id}`) are only scanned when the exact lookup produced no match at
+/// all, so a mock set with no path parameters — or a request that hits one
+/// exactly — never touches the pattern loop. A pattern match also always
+/// scores below an otherwise-equal exact match.
 pub fn find_matching_mock(
     context: &RequestContext,
     mocks: &HashMap<String, Vec<MockConfig>>,
@@ -641,35 +655,39 @@ pub fn find_matching_mock(
         }
     }
 
-    // Pattern match: scan mocks registered under the same method whose path
-    // uses :name/{name} segments.
-    let method_prefix = format!("{}:", context.method.to_uppercase());
-    for (key, mock_list) in mocks.iter() {
-        if *key == base_key {
-            continue; // already handled as an exact match above
-        }
-        let Some(path_part) = key.strip_prefix(method_prefix.as_str()) else {
-            continue;
-        };
-        if !is_pattern_path(path_part) {
-            continue;
-        }
-        let Some(pattern) = compile_path_pattern(path_part) else {
-            continue;
-        };
-        let Some(params) = match_path_pattern(&pattern, &context.path) else {
-            continue;
-        };
+    // Pattern match: only reached when nothing matched the exact key. Scans
+    // mocks registered under the same method whose path uses :name/{name}
+    // segments; each template's regex is compiled once process-wide, not
+    // once per request.
+    if candidates.is_empty() {
+        let method_prefix = format!("{}:", context.method.to_uppercase());
+        for (key, mock_list) in mocks.iter() {
+            if *key == base_key {
+                continue; // already handled as an exact match above
+            }
+            let Some(path_part) = key.strip_prefix(method_prefix.as_str()) else {
+                continue;
+            };
+            if !is_pattern_path(path_part) {
+                continue;
+            }
+            let Some(pattern) = compile_path_pattern(path_part) else {
+                continue;
+            };
+            let Some(params) = match_path_pattern(&pattern, &context.path) else {
+                continue;
+            };
 
-        for (index, mock) in mock_list.iter().enumerate() {
-            if let Some(score) = calculate_match_score(context, mock) {
-                candidates.push(MatchResult {
-                    mock: mock.clone(),
-                    score: score.saturating_sub(PATTERN_MATCH_PENALTY),
-                    index,
-                    path_params: params.clone(),
-                    matched_key: key.clone(),
-                });
+            for (index, mock) in mock_list.iter().enumerate() {
+                if let Some(score) = calculate_match_score(context, mock) {
+                    candidates.push(MatchResult {
+                        mock: mock.clone(),
+                        score: score.saturating_sub(PATTERN_MATCH_PENALTY),
+                        index,
+                        path_params: params.clone(),
+                        matched_key: key.clone(),
+                    });
+                }
             }
         }
     }
@@ -1299,5 +1317,262 @@ mod tests {
         )]);
 
         assert!(find_matching_mock(&path_param_context("/posts/1"), &mocks).is_none());
+    }
+
+    // ------------------------------------------------------------------
+    // Compilation caching / pattern short-circuit
+    // ------------------------------------------------------------------
+
+    fn plain_mock(method: &str, path: &str, marker: &str) -> MockConfig {
+        MockConfig {
+            method: method.to_string(),
+            path: path.to_string(),
+            status: 200,
+            response: serde_json::json!({"source": marker}),
+            consume_body: false,
+            query_params: None,
+            headers: None,
+            body: None,
+            delay_ms: None,
+            response_headers: None,
+            sequence: None,
+        }
+    }
+
+    fn mock_map(mocks: Vec<MockConfig>) -> HashMap<String, Vec<MockConfig>> {
+        let mut map: HashMap<String, Vec<MockConfig>> = HashMap::new();
+        for mock in mocks {
+            map.entry(crate::types::create_mock_key(&mock.method, &mock.path))
+                .or_default()
+                .push(mock);
+        }
+        map
+    }
+
+    #[test]
+    fn test_path_pattern_compiled_once_across_many_requests() {
+        // A template unique to this test, so the shared process-wide cache
+        // can't have been populated by another test.
+        let template = "/cache-probe-once/:id";
+        assert!(!path_pattern_is_cached(template));
+
+        let mocks = mock_map(vec![plain_mock("GET", template, "pattern")]);
+
+        for i in 0..50 {
+            let mut ctx =
+                RequestContext::new("GET".to_string(), format!("/cache-probe-once/{}", i));
+            ctx.path_params = HashMap::new();
+            let result = find_matching_mock(&ctx, &mocks).expect("pattern should match");
+            assert_eq!(result.mock.response["source"], "pattern");
+        }
+
+        // Compilation is memoized by template string, so the 50 requests above
+        // share the single entry created by the first one.
+        assert!(path_pattern_is_cached(template));
+        let first = compile_path_pattern(template).unwrap();
+        let second = compile_path_pattern(template).unwrap();
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn test_exact_match_never_compiles_pattern_routes() {
+        let template = "/cache-probe-skip/:id";
+        assert!(!path_pattern_is_cached(template));
+
+        let mocks = mock_map(vec![
+            plain_mock("GET", "/cache-probe-skip/42", "exact"),
+            plain_mock("GET", template, "pattern"),
+        ]);
+
+        let ctx = RequestContext::new("GET".to_string(), "/cache-probe-skip/42".to_string());
+        let result = find_matching_mock(&ctx, &mocks).expect("exact should match");
+
+        assert_eq!(result.mock.response["source"], "exact");
+        assert!(result.path_params.is_empty());
+        // The pattern loop never ran, so its template was never compiled.
+        assert!(
+            !path_pattern_is_cached(template),
+            "exact-match request reached the path-pattern compiler"
+        );
+    }
+
+    #[test]
+    fn test_pattern_still_used_when_exact_key_exists_but_does_not_match() {
+        let template = "/cache-probe-fallthrough/:id";
+        let mut exact = plain_mock("GET", "/cache-probe-fallthrough/42", "exact");
+        exact.query_params = Some(QueryParamMatcher {
+            params: HashMap::from([(
+                "required".to_string(),
+                QueryParamValue::Exact("yes".to_string()),
+            )]),
+            strict: false,
+        });
+
+        let mocks = mock_map(vec![exact, plain_mock("GET", template, "pattern")]);
+
+        // The exact key exists but its query matcher rejects the request, so
+        // the pattern scan must still run.
+        let ctx = RequestContext::new("GET".to_string(), "/cache-probe-fallthrough/42".to_string());
+        let result = find_matching_mock(&ctx, &mocks).expect("pattern should match");
+
+        assert_eq!(result.mock.response["source"], "pattern");
+        assert_eq!(result.path_params.get("id"), Some(&"42".to_string()));
+    }
+
+    #[test]
+    fn test_matcher_regex_is_compiled_once_per_pattern() {
+        let pattern = "^probe-[a-z]+$";
+        let matcher = HeaderMatcher {
+            required: HashMap::from([(
+                "x-probe".to_string(),
+                HeaderValue::Pattern(HeaderPattern::Regex(pattern.to_string())),
+            )]),
+            forbidden: Vec::new(),
+            strict: false,
+        };
+
+        let mut headers = HashMap::new();
+        headers.insert("x-probe".to_string(), "probe-value".to_string());
+
+        for _ in 0..100 {
+            assert!(match_headers(&headers, &matcher));
+        }
+
+        // Every one of those calls resolved to the same compiled handle.
+        let a = crate::regex_cache::compiled_regex(pattern).unwrap();
+        let b = crate::regex_cache::compiled_regex(pattern).unwrap();
+        assert!(Arc::ptr_eq(&a, &b));
+    }
+
+    #[test]
+    fn test_invalid_matcher_regex_never_matches() {
+        let matcher = HeaderMatcher {
+            required: HashMap::from([(
+                "x-bad".to_string(),
+                HeaderValue::Pattern(HeaderPattern::Regex("([unclosed".to_string())),
+            )]),
+            forbidden: Vec::new(),
+            strict: false,
+        };
+
+        let mut headers = HashMap::new();
+        headers.insert("x-bad".to_string(), "anything".to_string());
+
+        assert!(!match_headers(&headers, &matcher));
+    }
+}
+
+/// Coarse micro-benchmarks backing the numbers in `ADVANCED_MATCHING.md`'s
+/// "Performance Notes". Excluded from the normal suite; reproduce with:
+///
+/// ```text
+/// cargo test --release -- --ignored --nocapture
+/// ```
+#[cfg(test)]
+mod benches {
+    use super::*;
+    use std::time::Instant;
+
+    #[test]
+    #[ignore]
+    fn bench_regex_matcher() {
+        let pattern = "^[A-Za-z0-9]{32}$";
+        let value = "abcdefghijklmnopqrstuvwxyz012345";
+        let n = 100_000;
+
+        let start = Instant::now();
+        for _ in 0..n {
+            let re = Regex::new(pattern).unwrap();
+            assert!(re.is_match(value));
+        }
+        let uncached = start.elapsed();
+
+        let start = Instant::now();
+        for _ in 0..n {
+            let re = compiled_regex(pattern).unwrap();
+            assert!(re.is_match(value));
+        }
+        let cached_time = start.elapsed();
+
+        println!(
+            "regex: uncached {:?}/op, cached {:?}/op",
+            uncached / n,
+            cached_time / n
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn bench_path_pattern() {
+        let mut mocks: HashMap<String, Vec<MockConfig>> = HashMap::new();
+        for i in 0..20 {
+            let path = format!("/bench{}/:id", i);
+            mocks.insert(
+                format!("GET:{}", path),
+                vec![MockConfig {
+                    method: "GET".to_string(),
+                    path,
+                    status: 200,
+                    response: serde_json::json!({}),
+                    consume_body: false,
+                    query_params: None,
+                    headers: None,
+                    body: None,
+                    delay_ms: None,
+                    response_headers: None,
+                    sequence: None,
+                }],
+            );
+        }
+        mocks.insert(
+            "GET:/bench-exact".to_string(),
+            vec![MockConfig {
+                method: "GET".to_string(),
+                path: "/bench-exact".to_string(),
+                status: 200,
+                response: serde_json::json!({}),
+                consume_body: false,
+                query_params: None,
+                headers: None,
+                body: None,
+                delay_ms: None,
+                response_headers: None,
+                sequence: None,
+            }],
+        );
+
+        let n = 50_000;
+        let ctx = RequestContext::new("GET".to_string(), "/bench-exact".to_string());
+        let start = Instant::now();
+        for _ in 0..n {
+            assert!(find_matching_mock(&ctx, &mocks).is_some());
+        }
+        println!(
+            "exact match with 20 pattern routes loaded: {:?}/op",
+            start.elapsed() / n
+        );
+
+        let ctx = RequestContext::new("GET".to_string(), "/bench19/42".to_string());
+        let start = Instant::now();
+        for _ in 0..n {
+            assert!(find_matching_mock(&ctx, &mocks).is_some());
+        }
+        println!(
+            "pattern match with 20 pattern routes loaded: {:?}/op",
+            start.elapsed() / n
+        );
+
+        // Approximates the old per-request cost: recompiling all 20 templates.
+        let templates: Vec<String> = (0..20).map(|i| format!("/bench{}/:id", i)).collect();
+        let start = Instant::now();
+        for _ in 0..n {
+            for t in &templates {
+                assert!(build_path_pattern(t).is_some());
+            }
+        }
+        println!(
+            "recompiling 20 path templates: {:?}/op",
+            start.elapsed() / n
+        );
     }
 }

--- a/src/regex_cache.rs
+++ b/src/regex_cache.rs
@@ -1,0 +1,136 @@
+//! Process-wide memoization for anything expensive to compile from a string.
+//!
+//! Compiling a regex is orders of magnitude more expensive than running one,
+//! so every regex Mimic derives from a mock file — query/header/body matchers
+//! and path templates alike — is compiled once per distinct pattern string and
+//! shared from then on, rather than being rebuilt on every request.
+//!
+//! Failures are cached too (as `None`), so an invalid pattern is reported once
+//! instead of once per request.
+
+use regex::Regex;
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock, RwLock};
+use tracing::warn;
+
+/// A memo table mapping a source string to its compiled form, or to `None` if
+/// compilation failed.
+pub type CompileCache<T> = OnceLock<RwLock<HashMap<String, Option<Arc<T>>>>>;
+
+/// Look `key` up in `cache`, compiling it with `build` on first sight.
+///
+/// The lock is never held while `build` runs, so a slow compile can't block
+/// unrelated lookups. A concurrent duplicate compile is possible but harmless:
+/// both produce equivalent values and the first one stored wins.
+pub fn cached<T, F>(cache: &CompileCache<T>, key: &str, build: F) -> Option<Arc<T>>
+where
+    F: FnOnce(&str) -> Option<T>,
+{
+    let cache = cache.get_or_init(|| RwLock::new(HashMap::new()));
+
+    if let Ok(read) = cache.read() {
+        if let Some(hit) = read.get(key) {
+            return hit.clone();
+        }
+    }
+
+    let compiled = build(key).map(Arc::new);
+
+    if let Ok(mut write) = cache.write() {
+        write
+            .entry(key.to_string())
+            .or_insert_with(|| compiled.clone());
+    }
+
+    compiled
+}
+
+/// True if `key` has already been compiled into `cache`. Test-only probe used
+/// to assert that a code path never reached the compiler.
+#[cfg(test)]
+pub fn is_cached<T>(cache: &CompileCache<T>, key: &str) -> bool {
+    cache
+        .get()
+        .and_then(|c| c.read().ok().map(|r| r.contains_key(key)))
+        .unwrap_or(false)
+}
+
+/// Compile (or reuse) the regex for `pattern`. Returns `None` if the pattern
+/// is invalid, having logged the reason the first time it was seen.
+pub fn compiled_regex(pattern: &str) -> Option<Arc<Regex>> {
+    static CACHE: CompileCache<Regex> = OnceLock::new();
+    cached(&CACHE, pattern, |p| match Regex::new(p) {
+        Ok(re) => Some(re),
+        Err(e) => {
+            warn!("Invalid regex pattern '{}': {}", p, e);
+            None
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn test_same_pattern_compiles_once() {
+        static CACHE: CompileCache<Regex> = OnceLock::new();
+        static BUILDS: AtomicUsize = AtomicUsize::new(0);
+
+        let build = |p: &str| {
+            BUILDS.fetch_add(1, Ordering::SeqCst);
+            Regex::new(p).ok()
+        };
+
+        for _ in 0..100 {
+            let re = cached(&CACHE, r"^\d+$", build).expect("valid pattern");
+            assert!(re.is_match("42"));
+        }
+
+        assert_eq!(BUILDS.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_distinct_patterns_get_distinct_entries() {
+        static CACHE: CompileCache<Regex> = OnceLock::new();
+
+        let digits = cached(&CACHE, r"^\d+$", |p| Regex::new(p).ok()).unwrap();
+        let letters = cached(&CACHE, r"^[a-z]+$", |p| Regex::new(p).ok()).unwrap();
+
+        assert!(digits.is_match("42"));
+        assert!(!digits.is_match("abc"));
+        assert!(letters.is_match("abc"));
+        assert!(!letters.is_match("42"));
+    }
+
+    #[test]
+    fn test_invalid_pattern_is_cached_as_none() {
+        static CACHE: CompileCache<Regex> = OnceLock::new();
+        static BUILDS: AtomicUsize = AtomicUsize::new(0);
+
+        let build = |p: &str| {
+            BUILDS.fetch_add(1, Ordering::SeqCst);
+            Regex::new(p).ok()
+        };
+
+        for _ in 0..10 {
+            assert!(cached(&CACHE, "([unclosed", build).is_none());
+        }
+
+        assert_eq!(BUILDS.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn test_compiled_regex_returns_shared_handle() {
+        let a = compiled_regex(r"^shared-\w+$").unwrap();
+        let b = compiled_regex(r"^shared-\w+$").unwrap();
+        assert!(Arc::ptr_eq(&a, &b));
+        assert!(a.is_match("shared-value"));
+    }
+
+    #[test]
+    fn test_compiled_regex_rejects_invalid_pattern() {
+        assert!(compiled_regex("([unclosed-group").is_none());
+    }
+}


### PR DESCRIPTION
**Stack position: 3 of 6** — based on #69. Merge the roll-up PR to take all six at once.

Closes #53
Closes #54

## #53 — Path-parameter matching rescanned and recompiled every pattern route per request

`find_matching_mock` ran its pattern loop **unconditionally**, calling `compile_path_pattern` — a bare `Regex::new` — for every pattern route on every request, even when the O(1) exact lookup had already matched. That directly contradicted the README claim added in the same PR that introduced the code (#49): *"patterns are only checked when no exact match exists."*

The loop is now guarded on the exact lookup producing no candidates, which is the documented behavior. A request whose exact key exists but whose query/header/body matchers reject it still falls through to the pattern scan.

## #54 — Query/header/text-body regexes recompiled on every request

`match_query_param_value`, `match_header_value` and `match_text_body` each called `Regex::new` inline, per call, per request — in the hot path, under a read lock. Compiling a regex is orders of magnitude more expensive than running one.

## The fix

Both now go through the new `src/regex_cache.rs`: a process-wide memo table keyed by the pattern string. A given pattern costs one compile for the lifetime of the process. Hot reload doesn't invalidate it — the key is the pattern text, not the mock map. Failed compiles are cached as `None`, so an invalid pattern warns once rather than once per request.

## Measured

Release build, per request (`cargo test --release -- --ignored --nocapture`, see `mod benches` in `src/matcher.rs`):

| Operation | Before | After |
|---|---|---|
| One header regex matcher (`^[A-Za-z0-9]{32}$`) | ~46 µs | ~0.16 µs |
| Exact-path request, 20 template routes loaded | ~6.0 ms | ~0.3 µs |
| Path-param request, 20 template routes loaded | ~6.0 ms | ~7 µs |

The exact-path row is the big one and needs both halves of the fix: the scan is skipped when the exact lookup matched, and templates that *are* scanned aren't recompiled.

## Behavior change worth reviewing

Skipping the pattern scan on an exact match is what the README always claimed, but it is a real change in one edge case: a pattern mock carrying extra matchers could previously outscore a bare exact mock (`1000 + 500 - 100 = 1400` vs `1000`). It no longer gets the chance. If that combination is something you want to keep working, say so and I'll gate the short-circuit instead.

## Tests

- a template is compiled once across 50 requests and hands back the same `Arc`
- an exact-path request never reaches the path-pattern compiler — asserted with a cache probe, not a timing measurement
- a non-matching exact key still falls through to patterns
- an invalid matcher regex never matches
- cache unit tests: same pattern compiles once, distinct patterns stay distinct, invalid patterns cache as `None`

## Docs

README's Path Parameters performance claim now matches the code. `ADVANCED_MATCHING.md`'s "Performance Notes" replaces the unsourced "~1-5ms" line with the measured table above and a reproduction command.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7GhL45q8B6tjLEVNsMbyw)_