### PR TITLE
[5/6] fix: honor per-mock consume_body, isolate hot-reload failures per file

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,23 @@ Mimic reads mock definitions from JSON files in the `/app/mocks` directory (or `
   - `true` - Consume request body (required for file uploads, multipart/form-data)
   - `false` - Skip body consumption (faster, default behavior)
 
+### Hot Reload
+
+Mimic rescans the mocks directory every 2 seconds and picks up changes without
+a restart. **Failures are isolated per file**: if one file has invalid JSON —
+an editor mid-save, a teammate's work-in-progress in a shared mocks directory —
+every other file in that cycle still applies. A single typo can no longer block
+unrelated mock changes from taking effect.
+
+The broken file's own route is not dropped, either. It keeps serving its
+last successfully-loaded response until the file parses again, so routes don't
+flap in and out of existence while somebody is editing. Each failure is logged
+with the file name and parse error, plus a summary of how many endpoints were
+applied and how many were carried forward.
+
+Deletions still take effect normally: on a clean cycle (no parse errors) the
+mock set is replaced outright, so removing a file removes its route.
+
 ---
 
 ## 📁 Mock Examples
@@ -1077,6 +1094,22 @@ Mimic supports configurable request body consumption per endpoint via the `consu
 - Mimic responds immediately without reading the request body
 - Optimal for endpoints that don't need the body
 - Best performance and lowest memory usage
+
+The decision is made **per endpoint**, scoped to the mocks registered for the
+request's method and path — a `body` matcher on some unrelated mock elsewhere
+in your mocks directory has no effect on this one.
+
+Mimic reads the body when any mock that could serve the request:
+
+- sets `"consume_body": true`, **or**
+- declares a `body` matcher (it can't match what it hasn't read), **or**
+- interpolates `{{body.…}}` into its `response` or a sequence step's response
+
+...or when **no mock is registered at all** for that method and path, so the
+404 response and the request log can still show what the client sent.
+
+Otherwise the body is left unread — which is exactly what `consume_body: false`
+promises.
 
 ### When to Use consume_body: true
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,5 +1,6 @@
 use crate::matcher::{
-    find_matching_mock, parse_body, parse_headers, parse_query_string, MatchResult, RequestContext,
+    find_matching_mock, parse_body, parse_headers, parse_query_string, requires_body, MatchResult,
+    RequestContext,
 };
 use crate::template::{render_response, TemplateContext};
 use crate::types::{
@@ -93,41 +94,44 @@ pub async fn handle_request(
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
 
-    // Check if any mock needs body matching (acquire read lock)
-    let needs_body_matching = {
+    // Decide whether to read the body, scoped to the mocks that could actually
+    // serve this method+path — a `body` matcher or `consume_body: true` on some
+    // *other* endpoint is none of this request's business (acquire read lock)
+    let needs_body = {
         let mocks = state.mocks.read().await;
-        mocks.values().flatten().any(|mock| mock.body.is_some())
+        requires_body(&method_str, &path, &mocks)
     };
 
-    // Consume body if needed for matching or if consume_body is set.
-    //
     // The body is wrapped in `Limited` so the stream is cut off — and the
     // request rejected with 413 — as soon as it exceeds the cap, rather than
     // being buffered in full and only then measured.
     let max_body = max_body_size();
-    let body_bytes: Option<Bytes> =
-        if needs_body_matching || matches!(method, Method::POST | Method::PUT | Method::PATCH) {
-            match Limited::new(body, max_body).collect().await {
-                Ok(collected) => {
-                    let bytes = collected.to_bytes();
-                    debug!("Consumed {} bytes from request body", bytes.len());
-                    Some(bytes)
-                }
-                Err(e) if is_length_limit(&*e) => {
-                    warn!(
-                        "Rejecting {} {}: request body exceeds the {}-byte limit",
-                        method_str, path, max_body
-                    );
-                    return payload_too_large(&method_str, &path, max_body);
-                }
-                Err(e) => {
-                    debug!("Failed to read body: {}", e);
-                    None
-                }
+    let body_bytes: Option<Bytes> = if needs_body {
+        match Limited::new(body, max_body).collect().await {
+            Ok(collected) => {
+                let bytes = collected.to_bytes();
+                debug!("Consumed {} bytes from request body", bytes.len());
+                Some(bytes)
             }
-        } else {
-            None
-        };
+            Err(e) if is_length_limit(&*e) => {
+                warn!(
+                    "Rejecting {} {}: request body exceeds the {}-byte limit",
+                    method_str, path, max_body
+                );
+                return payload_too_large(&method_str, &path, max_body);
+            }
+            Err(e) => {
+                debug!("Failed to read body: {}", e);
+                None
+            }
+        }
+    } else {
+        debug!(
+            "Skipping request body: no mock for {} {} needs it",
+            method_str, path
+        );
+        None
+    };
 
     // Build request context for matching
     let mut context = RequestContext {
@@ -2394,5 +2398,120 @@ mod tests {
                     self.chunk_size
                 ])))))
         }
+    }
+
+    // ------------------------------------------------------------------
+    // Per-mock body consumption (#52)
+    // ------------------------------------------------------------------
+
+    fn body_mock(path: &str, consume_body: bool) -> MockConfig {
+        MockConfig {
+            method: "POST".to_string(),
+            path: path.to_string(),
+            status: 202,
+            response: json!({"queued": true}),
+            consume_body,
+            query_params: None,
+            headers: None,
+            body: None,
+            delay_ms: None,
+            response_headers: None,
+            sequence: None,
+        }
+    }
+
+    async fn post_and_read_recorded_body(
+        state: &AppState,
+        path: &str,
+        payload: &'static str,
+    ) -> Option<String> {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "text/plain".parse().unwrap());
+
+        let _ = handle_request(
+            Method::POST,
+            path.parse().unwrap(),
+            headers,
+            State(state.clone()),
+            Body::from(payload),
+        )
+        .await;
+
+        let response = list_requests(State(state.clone()), Query(RequestFilter::default())).await;
+        let requests = response.0["requests"].as_array().unwrap();
+        requests
+            .last()
+            .and_then(|r| r["body"].as_str())
+            .map(|s| s.to_string())
+    }
+
+    fn state_with(mocks: Vec<MockConfig>) -> AppState {
+        let mut map: HashMap<String, Vec<MockConfig>> = HashMap::new();
+        for m in mocks {
+            map.entry(crate::types::create_mock_key(&m.method, &m.path))
+                .or_default()
+                .push(m);
+        }
+        AppState::new(Arc::new(tokio::sync::RwLock::new(map)))
+    }
+
+    #[tokio::test]
+    async fn test_consume_body_false_skips_reading_the_body() {
+        let state = state_with(vec![body_mock("/trigger-job", false)]);
+        let recorded = post_and_read_recorded_body(&state, "/trigger-job", "some=body").await;
+        assert_eq!(
+            recorded, None,
+            "consume_body: false must leave the body unread"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_consume_body_true_reads_the_body() {
+        let state = state_with(vec![body_mock("/upload", true)]);
+        let recorded = post_and_read_recorded_body(&state, "/upload", "file=contents").await;
+        assert_eq!(recorded.as_deref(), Some("file=contents"));
+    }
+
+    #[tokio::test]
+    async fn test_body_matcher_implies_consumption_without_consume_body() {
+        let mut mock = body_mock("/match-me", false);
+        mock.body = Some(BodyMatcher::Any);
+        let state = state_with(vec![mock]);
+
+        let recorded = post_and_read_recorded_body(&state, "/match-me", "payload").await;
+        assert_eq!(recorded.as_deref(), Some("payload"));
+    }
+
+    #[tokio::test]
+    async fn test_body_template_implies_consumption_without_consume_body() {
+        let mut mock = body_mock("/echo-body", false);
+        mock.response = json!({"echoed": "{{body.field}}"});
+        let state = state_with(vec![mock]);
+
+        let recorded = post_and_read_recorded_body(&state, "/echo-body", "field=value").await;
+        assert_eq!(recorded.as_deref(), Some("field=value"));
+    }
+
+    #[tokio::test]
+    async fn test_another_mocks_body_matcher_does_not_force_consumption() {
+        // The regression this fixes: `needs_body_matching` used to be global,
+        // so an unrelated mock's body matcher made every request buffer.
+        let mut unrelated = body_mock("/has-matcher", false);
+        unrelated.path = "/has-matcher".to_string();
+        unrelated.body = Some(BodyMatcher::Any);
+
+        let state = state_with(vec![unrelated, body_mock("/trigger-job", false)]);
+
+        let recorded = post_and_read_recorded_body(&state, "/trigger-job", "some=body").await;
+        assert_eq!(recorded, None);
+    }
+
+    #[tokio::test]
+    async fn test_unmatched_request_still_records_its_body() {
+        // No mock covers this path, so the request 404s either way — capture
+        // the body so the request log can show what was actually sent.
+        let state = state_with(vec![body_mock("/trigger-job", false)]);
+        let recorded = post_and_read_recorded_body(&state, "/nowhere", "debug=me").await;
+        assert_eq!(recorded.as_deref(), Some("debug=me"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use handler::{
     reset_sequences, AppState,
 };
 use loader::{load_mocks, load_mocks_map};
+use std::collections::HashMap;
 use std::env;
 use tower_http::trace::TraceLayer;
 use tracing::{debug, info, warn};
@@ -76,16 +77,9 @@ async fn main() {
                         errors: 1,
                     }
                 });
-            if result.errors > 0 {
-                warn!(
-                    "🔄 Hot reload: {} error(s) loading mocks, keeping previous mock set",
-                    result.errors
-                );
-                continue;
-            }
             let mut store = reload_mocks.write().await;
             let old_len = store.len();
-            *store = result.mocks;
+            *store = apply_reload(&store, result);
             let new_len = store.len();
             if old_len != new_len {
                 info!(
@@ -120,6 +114,45 @@ async fn main() {
     axum::serve(listener, app).await.unwrap_or_else(|e| {
         panic!("Server error: {}", e);
     });
+}
+
+/// Build the mock map a hot-reload cycle should install, given what's
+/// currently registered and what the cycle managed to load.
+///
+/// A clean cycle replaces the map outright. A cycle with per-file errors —
+/// one file mid-save, one teammate's typo — applies every mock that *did*
+/// parse, so unrelated edits still take effect, and carries forward any route
+/// the previous map had that this cycle didn't produce. That last part keeps
+/// the broken file's own route serving its last-known-good response instead of
+/// disappearing and reappearing as the file is fixed.
+///
+/// `loader.rs` has already logged which files failed and why.
+fn apply_reload(
+    current: &HashMap<String, Vec<types::MockConfig>>,
+    result: loader::LoadResult,
+) -> HashMap<String, Vec<types::MockConfig>> {
+    if result.errors == 0 {
+        return result.mocks;
+    }
+
+    let mut merged = result.mocks;
+    let mut retained = 0usize;
+    for (key, mocks) in current {
+        if !merged.contains_key(key) {
+            merged.insert(key.clone(), mocks.clone());
+            retained += 1;
+        }
+    }
+
+    warn!(
+        "🔄 Hot reload: {} file(s) failed to load; applied {} endpoint(s) that parsed, \
+         kept {} previously-registered endpoint(s)",
+        result.errors,
+        merged.len() - retained,
+        retained
+    );
+
+    merged
 }
 
 fn create_router(state: AppState) -> Router {
@@ -379,5 +412,129 @@ mod tests {
             remaining: handler::max_body_size() * 2,
         }))
         .await;
+    }
+
+    // ------------------------------------------------------------------
+    // Hot-reload failure isolation (#57)
+    // ------------------------------------------------------------------
+
+    use loader::LoadResult;
+    use types::MockConfig;
+
+    fn mock(method: &str, path: &str, marker: &str) -> MockConfig {
+        MockConfig {
+            method: method.to_string(),
+            path: path.to_string(),
+            status: 200,
+            response: serde_json::json!({"source": marker}),
+            consume_body: false,
+            query_params: None,
+            headers: None,
+            body: None,
+            delay_ms: None,
+            response_headers: None,
+            sequence: None,
+        }
+    }
+
+    fn map(mocks: Vec<MockConfig>) -> HashMap<String, Vec<MockConfig>> {
+        let mut out: HashMap<String, Vec<MockConfig>> = HashMap::new();
+        for m in mocks {
+            out.entry(types::create_mock_key(&m.method, &m.path))
+                .or_default()
+                .push(m);
+        }
+        out
+    }
+
+    fn write_mock(dir: &std::path::Path, name: &str, contents: &str) {
+        std::fs::write(dir.join(name), contents).unwrap();
+    }
+
+    #[test]
+    fn test_clean_reload_replaces_the_map() {
+        let current = map(vec![mock("GET", "/old", "old")]);
+        let result = LoadResult {
+            mocks: map(vec![mock("GET", "/new", "new")]),
+            errors: 0,
+        };
+
+        let next = apply_reload(&current, result);
+
+        assert!(next.contains_key("GET:/new"));
+        assert!(
+            !next.contains_key("GET:/old"),
+            "a clean reload must not resurrect deleted routes"
+        );
+    }
+
+    #[test]
+    fn test_broken_file_does_not_block_unrelated_changes() {
+        // /a was already registered; /b is new and parsed fine this cycle;
+        // some third file failed to parse.
+        let current = map(vec![mock("GET", "/a", "a")]);
+        let result = LoadResult {
+            mocks: map(vec![mock("GET", "/a", "a"), mock("GET", "/b", "b")]),
+            errors: 1,
+        };
+
+        let next = apply_reload(&current, result);
+
+        assert!(
+            next.contains_key("GET:/b"),
+            "a valid file's route must register even when another file is broken"
+        );
+        assert_eq!(next["GET:/a"][0].response["source"], "a");
+    }
+
+    #[test]
+    fn test_broken_files_route_keeps_its_last_good_response() {
+        // /broken parsed last cycle but not this one. Its route must keep
+        // serving rather than flap out of existence while the file is fixed.
+        let current = map(vec![
+            mock("GET", "/broken", "last-good"),
+            mock("GET", "/ok", "ok"),
+        ]);
+        let result = LoadResult {
+            mocks: map(vec![mock("GET", "/ok", "ok-updated")]),
+            errors: 1,
+        };
+
+        let next = apply_reload(&current, result);
+
+        assert_eq!(next["GET:/broken"][0].response["source"], "last-good");
+        assert_eq!(next["GET:/ok"][0].response["source"], "ok-updated");
+    }
+
+    #[test]
+    fn test_reload_from_disk_with_one_invalid_file() {
+        let dir = tempfile::tempdir().unwrap();
+        write_mock(
+            dir.path(),
+            "a.json",
+            r#"{"method":"GET","path":"/a","status":200,"response":{}}"#,
+        );
+        let current = load_mocks_map(dir.path().to_str().unwrap());
+        assert_eq!(current.errors, 0);
+        assert!(current.mocks.contains_key("GET:/a"));
+
+        // A second valid mock lands at the same time as a file mid-save.
+        write_mock(
+            dir.path(),
+            "b.json",
+            r#"{"method":"GET","path":"/b","status":200,"response":{}}"#,
+        );
+        write_mock(dir.path(), "c.json", "{invalid json");
+
+        let result = load_mocks_map(dir.path().to_str().unwrap());
+        assert_eq!(result.errors, 1);
+
+        let next = apply_reload(&current.mocks, result);
+
+        assert!(next.contains_key("GET:/a"));
+        assert!(
+            next.contains_key("GET:/b"),
+            "/b is independently valid and must become available"
+        );
     }
 }

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -643,6 +643,72 @@ fn path_specificity(path: &str) -> u32 {
         .count() as u32
 }
 
+/// Decide whether the request body must be read, knowing only the method and
+/// path — this runs *before* the body is consumed, so the eventual matched
+/// mock isn't known yet.
+///
+/// The body is read when either:
+///
+/// - some mock registered for this method+path asks for it, i.e. it declares a
+///   `body` matcher, sets `consume_body: true`, or interpolates `{{body.…}}`
+///   into its response; or
+/// - no mock is registered for this method+path at all, so the request is
+///   heading for a 404 and the body is worth capturing for the request log.
+///
+/// Otherwise the body is left unread, which is what `consume_body: false`
+/// (the default) promises.
+pub fn requires_body(method: &str, path: &str, mocks: &HashMap<String, Vec<MockConfig>>) -> bool {
+    let mut any_candidate = false;
+
+    /// A single mock's own answer to "do I need the request body?"
+    fn mock_needs_body(mock: &MockConfig) -> bool {
+        mock.consume_body
+            || mock.body.is_some()
+            || crate::template::references_body(&mock.response)
+            || mock.sequence.as_deref().is_some_and(|steps| {
+                steps
+                    .iter()
+                    .any(|step| crate::template::references_body(&step.response))
+            })
+    }
+
+    let base_key = crate::types::create_mock_key(method, path);
+    if let Some(mock_list) = mocks.get(&base_key) {
+        any_candidate = true;
+        if mock_list.iter().any(mock_needs_body) {
+            return true;
+        }
+    }
+
+    // Pattern routes can serve this path too, either as the winner or as the
+    // fallback when the exact key's matchers reject the request.
+    let method_prefix = format!("{}:", method.to_uppercase());
+    for (key, mock_list) in mocks.iter() {
+        if *key == base_key {
+            continue;
+        }
+        let Some(path_part) = key.strip_prefix(method_prefix.as_str()) else {
+            continue;
+        };
+        if !is_pattern_path(path_part) {
+            continue;
+        }
+        let Some(pattern) = compile_path_pattern(path_part) else {
+            continue;
+        };
+        if match_path_pattern(&pattern, path).is_none() {
+            continue;
+        }
+
+        any_candidate = true;
+        if mock_list.iter().any(mock_needs_body) {
+            return true;
+        }
+    }
+
+    !any_candidate
+}
+
 /// Find the best matching mock for a request.
 ///
 /// Exact "METHOD:path" lookups are O(1) and tried first. Parameterized paths

--- a/src/template.rs
+++ b/src/template.rs
@@ -36,6 +36,25 @@ pub fn render_response(value: &Value, ctx: &TemplateContext) -> Value {
     render_value(value, ctx)
 }
 
+/// True if any template inside `value` reads from the request body, i.e. uses
+/// a `{{body.…}}` expression.
+///
+/// Used before the body is read to decide whether a mock's response actually
+/// needs it — a response that never mentions `{{body.…}}` doesn't.
+pub fn references_body(value: &Value) -> bool {
+    match value {
+        Value::String(s) => {
+            s.contains("{{")
+                && template_regex()
+                    .captures_iter(s)
+                    .any(|caps| &caps[1] == "body")
+        }
+        Value::Object(map) => map.values().any(references_body),
+        Value::Array(arr) => arr.iter().any(references_body),
+        _ => false,
+    }
+}
+
 fn contains_template(value: &Value) -> bool {
     match value {
         Value::String(s) => s.contains("{{"),


### PR DESCRIPTION
**Stack position: 5 of 6** — based on #71. Merge the roll-up PR to take all six at once.

Closes #52
Closes #57

## #52 — `consume_body` was dead configuration

Nothing in `handler.rs` ever read the field. Whether a body got buffered was decided by a global scan (*"does **any** loaded mock anywhere declare a body matcher?"*) OR'd with *"is the method POST/PUT/PATCH"*. So:

- `consume_body: false` on an upload endpoint bought nothing — POST bodies were consumed regardless
- an unrelated GET mock paid for body buffering because some *other* file in `mocks/` happened to use body matching

The README dedicates a whole section to a feature that was a no-op.

**This takes Option A from the issue** — restore the documented per-mock semantics. The new `matcher::requires_body` runs before the body is read, when only the method and path are known, and consults only the mocks that could serve that method+path (exact-key mocks plus any path template matching it). The body is read when such a mock:

- sets `"consume_body": true`, **or**
- declares a `body` matcher (it can't match what it hasn't read), **or**
- interpolates `{{body.…}}` into its `response` or a sequence step's response

...or when **no mock is registered at all** for that method+path — the request is heading for a 404 and the body is worth having in the request log.

> The `{{body.…}}` clause was not in the issue's write-up. Three existing templating tests caught it: templating reads the body just as much as matching does, so scoping consumption to matchers alone would have silently broken every `{{body.x}}` mock that didn't also set `consume_body: true`.

### Behavior change — please read

A POST/PUT/PATCH to a mock that neither sets `consume_body: true` nor needs the body **no longer has its body drained**. That is the contract the README always described, and it means the README's existing guidance to set `consume_body: true` on upload endpoints is now load-bearing rather than decorative. Existing mock files that rely on the current always-consume behavior for large uploads will need that flag set.

## #57 — A single malformed mock file blocked hot-reload of every other pending change

The reload task discarded the whole result set whenever `errors > 0`, so one file mid-save — or one teammate's WIP in a shared `mocks/` directory — stalled *every* unrelated edit, with a single `warn!` as the only signal.

Merging now lives in `apply_reload`, extracted from the spawn closure so it can be tested:

- **clean cycle** → replaces the map outright, so deleting a file still removes its route
- **cycle with errors** → applies everything that parsed, and carries forward any previously-registered route the cycle didn't produce

That last part is the second acceptance criterion: the broken file's own route keeps serving its last-known-good response instead of flapping in and out while somebody edits it. The warning now reports how many endpoints were applied and how many were carried forward.

## Tests

**consume_body:** `false` leaves the body unread while `true` reads it; a body matcher or a `{{body.…}}` template each imply consumption on their own; another mock's body matcher no longer forces consumption; an unmatched request still records its body.

**hot reload:** a clean cycle drops deleted routes; a broken file doesn't block an unrelated valid one; the broken file's route retains its last good response; an end-to-end pass over a temp directory with one valid and one invalid file registers the valid one.

## Verified against a running server

```
/b registers while c.json is invalid          → 200
unrelated /users/1 keeps working              → 200
keep.json broken → /keep serves last-good     → 200 {"source":"last-good"}
keep.json deleted, clean cycle → /keep gone   → 404
consume_body:false POST → no body recorded
consume_body:true  POST → body recorded
```

## Docs

README gains a **Hot Reload** section describing per-file isolation, and the **Request Body Consumption** section now states the exact per-endpoint rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7GhL45q8B6tjLEVNsMbyw)_