### PR TITLE
chore(deps): bump regex, tokio, serde_json, and http-body (#78–#81)

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,8 +3,11 @@ name: Unit Tests
 on:
   push:
     branches: [ main ]
+  # Every pull request, not just those targeting `main`. A stacked PR is based
+  # on the branch below it in the stack, so a `branches: [main]` filter would
+  # leave every PR in a stack except the bottom one untested until it is
+  # merged and auto-retargeted.
   pull_request:
-    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -608,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -686,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -825,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tower = "0.5"
 tower-http = { version = "0.7", features = ["trace"] }
 http-body-util = "0.1.4"
-regex = "1.12"
+regex = "1.13"
 urlencoding = "2.1"
 bytes = "1.12.1"
 chrono = { version = "0.4.45", features = ["serde"] }


### PR DESCRIPTION
**Stack 1/6** — base of the fix stack. Merge in order; each PR targets the one below it.

| # | PR | Fixes |
|---|---|---|
| **1** | **this one** | **#78 #79 #80 #81** |
| 2 | `fix/84-mocks-dir` | #84 |
| 3 | `fix/85-plus-decoding` | #85 |
| 4 | `fix/86-loader-order` | #86 |
| 5 | `fix/87-reserved-routes` | #87 |
| 6 | `fix/88-body-redaction` | #88 |

---

Rolls the four open Dependabot bumps into one lockfile update, so the five fix PRs above build against a single dependency set rather than four that each have to be merged and re-resolved.

- **regex 1.12.4 → 1.13.1** — fixes incorrect match offsets being reported. Mimic compiles a regex per path-pattern mock, so the offsets a capture group reports are load-bearing for `{{path.*}}`.
- regex-automata 0.4.13 → 0.4.18 (pulled in by the above)
- tokio 1.52.3 → 1.53.1
- serde_json 1.0.150 → 1.0.151
- http-body 1.0.1 → 1.1.0 (dev-dependency)

`regex` is the only version requirement that had to move in `Cargo.toml` (`"1.12"` → `"1.13"`); the rest were already loose enough that only `Cargo.lock` changes. Versions match the Dependabot PRs exactly.

### One extra change, flagged

CI's `pull_request` trigger drops its `branches: [main]` filter. A stacked PR is based on the branch below it, so that filter would leave every PR in this stack except this one **untested** until it is merged and auto-retargeted to `main`. If you'd rather not widen the trigger, say so and I'll drop the hunk — but then only this PR gets a CI run.

Closes #78
Closes #79
Closes #80
Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)