### PR TITLE
fix: resolve the mocks directory instead of hardcoding /app/mocks (#84)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,12 @@ PORT=8080
 
 # Logging level: trace, debug, info, warn, error (default: info)
 RUST_LOG=info
+
+# Directory (or single JSON file) mock definitions are read from.
+# Unset, Mimic uses /app/mocks when it exists — that's the Docker image, whose
+# volume mount creates it — and ./mocks otherwise, which is what a local
+# `cargo run` or an installed binary picks up. Subdirectories are searched too.
+# MIMIC_MOCKS_DIR=./mocks
 # Maximum request body size Mimic will buffer, in bytes (default: 10485760 = 10 MB)
 # Requests over this size are rejected with 413 Payload Too Large before the
 # body is buffered.

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,10 @@ RUN chmod +x /usr/local/bin/mimic
 # Set default environment variables (can be overridden in docker-compose)
 ENV PORT=8080
 ENV RUST_LOG=info
+# Stated rather than inferred: outside Docker the server falls back to ./mocks,
+# and the image's contract is the volume mount every `docker run -v
+# ./mocks:/app/mocks` command in the README already uses.
+ENV MIMIC_MOCKS_DIR=/app/mocks
 
 # Run the application
 ENTRYPOINT ["/usr/local/bin/mimic"]

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ PORT=8080
 # Logging level: trace, debug, info, warn, error (default: info)
 RUST_LOG=info
 
+# Directory (or single JSON file) mocks are read from.
+# Default: /app/mocks when it exists (the Docker image), else ./mocks.
+MIMIC_MOCKS_DIR=./mocks
+
 # Maximum request body Mimic will buffer, in bytes (default: 10485760 = 10 MB)
 MIMIC_MAX_BODY_SIZE=10485760
 
@@ -136,7 +140,28 @@ MIMIC_ACTIVE_TAGS=happy-path,smoke-test
 
 ### Mock Files
 
-Mimic reads mock definitions from JSON files in the `/app/mocks` directory (or `./mocks` locally).
+Mimic reads mock definitions from JSON files, searching the directory it
+resolves at startup and every subdirectory beneath it.
+
+**Where it reads from**, in order:
+
+1. `MIMIC_MOCKS_DIR`, if set — a directory or a single `.json` file. Used
+   verbatim: a path that doesn't exist is reported as missing rather than
+   silently replaced by a default.
+2. `/app/mocks`, if it exists — the Docker image's mount point, so every
+   `docker run -v $(pwd)/mocks:/app/mocks` command below resolves exactly there.
+3. `./mocks`, relative to the working directory — what `cargo run`, `make dev`,
+   an installed binary, or a release build picks up from a clone of this repo.
+
+The directory Mimic actually resolved is logged at startup, and a run that
+registers no mocks says which of the two reasons applies — the directory isn't
+there, or it's there and holds no mock files:
+
+```
+INFO mimic: Configuration:
+INFO mimic:   Mocks directory: ./mocks (default, relative to the working directory)
+INFO mimic: Loaded 31 mock(s)
+```
 
 **Mock File Structure:**
 
@@ -1071,6 +1096,12 @@ mimic import-openapi ./spec.yaml --out ./mocks/generated
 
 JSON and YAML specs are both accepted. The importer writes one **live** mock file per operation — built from its primary response — plus an inert `.json.disabled` file for every other documented status. The output is plain `MockConfig` JSON, so it hot-reloads like any other mock and can be hand-edited afterwards.
 
+The default output directory, `./mocks/generated`, sits inside the `./mocks`
+the server falls back to locally — so `mimic import-openapi ./spec.yaml && mimic`
+serves the generated mocks with nothing else to configure. When `--out` points
+elsewhere, the importer prints the exact command to start the server against
+it.
+
 ### Options
 
 | Option | Default | Description |
@@ -1324,6 +1355,13 @@ make dev
 
 # Or using Cargo directly
 cargo run
+```
+
+Either one serves the mocks in this repo's `./mocks` directory — no
+configuration needed. To read a different directory, set `MIMIC_MOCKS_DIR`:
+
+```bash
+MIMIC_MOCKS_DIR=./fixtures/staging cargo run
 ```
 
 3. **Run tests:**

--- a/agents.md
+++ b/agents.md
@@ -14,7 +14,7 @@
 
 ### 1. **Loader Agent** (`src/loader.rs`)
 - **Purpose:** Load mock configurations from JSON files
-- **Inputs:** `/app/mocks/` directory with JSON mock files
+- **Inputs:** the resolved mocks directory with JSON mock files — `MIMIC_MOCKS_DIR`, else `/app/mocks` when it exists, else `./mocks`
 - **Outputs:** `HashMap<String, MockConfig>` for O(1) lookup
 - **Responsibilities:** Scan, parse, validate mock files; build method:path index
 
@@ -59,7 +59,7 @@
 
 ### Startup Phase
 1. **Logger Agent** → Initialize logging
-2. **Loader Agent** → Scan `/app/mocks/`, parse JSON, build HashMap
+2. **Loader Agent** → Resolve the mocks directory, scan it, parse JSON, build HashMap
 3. **Router Agent** → Start HTTP server on port 8080
 
 ### Request Phase

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -12,6 +12,106 @@ pub struct LoadResult {
     pub errors: usize,
 }
 
+// ============================================================================
+// Mocks directory resolution
+// ============================================================================
+
+/// Environment variable naming the directory (or single file) mocks are read
+/// from, overriding the defaults below.
+pub const MOCKS_DIR_ENV: &str = "MIMIC_MOCKS_DIR";
+
+/// Where the Docker image mounts mocks. Probed first when the variable is
+/// unset, so every existing `docker run -v ./mocks:/app/mocks` keeps resolving
+/// exactly where it always did.
+pub const DOCKER_MOCKS_DIR: &str = "/app/mocks";
+
+/// Where a local run keeps its mocks — the directory the README has always
+/// said Mimic reads, and the parent of the importer's default output.
+pub const LOCAL_MOCKS_DIR: &str = "./mocks";
+
+/// How [`resolve_mocks_dir`] arrived at a directory.
+///
+/// Carried alongside the path so startup can say *why* it is reading where it
+/// is reading: "loaded 0 mocks" is a very different problem depending on
+/// whether the operator named the directory or Mimic guessed it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MocksDirOrigin {
+    /// `MIMIC_MOCKS_DIR` was set to a non-empty value.
+    Configured,
+    /// Defaulted to the Docker mount point, which exists.
+    Docker,
+    /// Defaulted to `./mocks`, relative to the working directory.
+    Local,
+}
+
+impl MocksDirOrigin {
+    /// A short phrase for the startup log.
+    pub fn describe(self) -> &'static str {
+        match self {
+            MocksDirOrigin::Configured => "from MIMIC_MOCKS_DIR",
+            MocksDirOrigin::Docker => "default, Docker mount point",
+            MocksDirOrigin::Local => "default, relative to the working directory",
+        }
+    }
+}
+
+/// The mocks directory a run will read, and how it was chosen.
+#[derive(Debug, Clone)]
+pub struct ResolvedMocksDir {
+    pub path: String,
+    pub origin: MocksDirOrigin,
+    /// Whether the resolved path exists at resolution time. Only a snapshot —
+    /// hot reload re-checks every cycle, so a directory created after startup
+    /// still gets picked up.
+    pub exists: bool,
+}
+
+/// Resolve the mocks directory from the environment and the filesystem.
+///
+/// `MIMIC_MOCKS_DIR` wins outright and is used verbatim, present or not: an
+/// operator who named a directory wants to be told it's missing, not to have
+/// Mimic quietly read a different one. With the variable unset, `/app/mocks`
+/// is used when it exists — that's the Docker image — and `./mocks` otherwise.
+pub fn resolve_mocks_dir() -> ResolvedMocksDir {
+    resolve_mocks_dir_from(std::env::var(MOCKS_DIR_ENV).ok(), |path| {
+        Path::new(path).exists()
+    })
+}
+
+/// [`resolve_mocks_dir`] with the environment and the filesystem injected.
+///
+/// Split out so the resolution rule is testable without mutating a
+/// process-wide environment variable that every other test shares.
+pub fn resolve_mocks_dir_from(
+    configured: Option<String>,
+    path_exists: impl Fn(&str) -> bool,
+) -> ResolvedMocksDir {
+    if let Some(raw) = configured {
+        let trimmed = raw.trim();
+        if !trimmed.is_empty() {
+            return ResolvedMocksDir {
+                exists: path_exists(trimmed),
+                path: trimmed.to_string(),
+                origin: MocksDirOrigin::Configured,
+            };
+        }
+    }
+
+    if path_exists(DOCKER_MOCKS_DIR) {
+        return ResolvedMocksDir {
+            path: DOCKER_MOCKS_DIR.to_string(),
+            origin: MocksDirOrigin::Docker,
+            exists: true,
+        };
+    }
+
+    ResolvedMocksDir {
+        exists: path_exists(LOCAL_MOCKS_DIR),
+        path: LOCAL_MOCKS_DIR.to_string(),
+        origin: MocksDirOrigin::Local,
+    }
+}
+
 /// Loads mock configurations from a directory or file into a raw HashMap.
 ///
 /// Args:
@@ -596,6 +696,105 @@ mod tests {
             result.mocks["POST:/login"][0].source.as_deref(),
             Some(file.to_str().unwrap())
         );
+    }
+
+    // ------------------------------------------------------------------
+    // Mocks directory resolution (#84)
+    // ------------------------------------------------------------------
+
+    /// A filesystem stub: only the listed paths exist.
+    fn only<'a>(existing: &'a [&'a str]) -> impl Fn(&str) -> bool + 'a {
+        move |path: &str| existing.contains(&path)
+    }
+
+    #[test]
+    fn test_docker_default_is_unchanged_when_the_mount_point_exists() {
+        // The whole point of probing /app/mocks first: every published
+        // `docker run -v ./mocks:/app/mocks` command has to keep working
+        // byte-for-byte.
+        let resolved = resolve_mocks_dir_from(None, only(&[DOCKER_MOCKS_DIR, LOCAL_MOCKS_DIR]));
+        assert_eq!(resolved.path, DOCKER_MOCKS_DIR);
+        assert_eq!(resolved.origin, MocksDirOrigin::Docker);
+        assert!(resolved.exists);
+    }
+
+    #[test]
+    fn test_falls_back_to_local_mocks_outside_docker() {
+        // `cargo run` from a fresh clone: /app/mocks is not a directory
+        // anyone has, ./mocks is the one the repo ships.
+        let resolved = resolve_mocks_dir_from(None, only(&[LOCAL_MOCKS_DIR]));
+        assert_eq!(resolved.path, LOCAL_MOCKS_DIR);
+        assert_eq!(resolved.origin, MocksDirOrigin::Local);
+        assert!(resolved.exists);
+    }
+
+    #[test]
+    fn test_falls_back_to_local_mocks_even_when_nothing_exists() {
+        // Nothing to read, but the path reported has to be the one a user can
+        // act on — `./mocks`, not a Docker path they'll never have.
+        let resolved = resolve_mocks_dir_from(None, only(&[]));
+        assert_eq!(resolved.path, LOCAL_MOCKS_DIR);
+        assert!(!resolved.exists);
+    }
+
+    #[test]
+    fn test_env_var_wins_over_both_defaults() {
+        let resolved = resolve_mocks_dir_from(
+            Some("/srv/fixtures".to_string()),
+            only(&["/srv/fixtures", DOCKER_MOCKS_DIR, LOCAL_MOCKS_DIR]),
+        );
+        assert_eq!(resolved.path, "/srv/fixtures");
+        assert_eq!(resolved.origin, MocksDirOrigin::Configured);
+    }
+
+    #[test]
+    fn test_env_var_is_honored_even_when_it_does_not_exist() {
+        // Silently falling back would leave a typo'd MIMIC_MOCKS_DIR looking
+        // exactly like a working one that happens to be empty.
+        let resolved = resolve_mocks_dir_from(
+            Some("/typo/mocks".to_string()),
+            only(&[DOCKER_MOCKS_DIR, LOCAL_MOCKS_DIR]),
+        );
+        assert_eq!(resolved.path, "/typo/mocks");
+        assert_eq!(resolved.origin, MocksDirOrigin::Configured);
+        assert!(!resolved.exists);
+    }
+
+    #[test]
+    fn test_env_var_is_trimmed_and_an_empty_value_means_unset() {
+        let trimmed = resolve_mocks_dir_from(Some("  /srv/fixtures  ".to_string()), only(&[]));
+        assert_eq!(trimmed.path, "/srv/fixtures");
+
+        // `MIMIC_MOCKS_DIR=` in a .env file must not resolve to "".
+        for blank in ["", "   "] {
+            let resolved =
+                resolve_mocks_dir_from(Some(blank.to_string()), only(&[LOCAL_MOCKS_DIR]));
+            assert_eq!(
+                resolved.path, LOCAL_MOCKS_DIR,
+                "an empty {} should behave as if it were unset",
+                MOCKS_DIR_ENV
+            );
+        }
+    }
+
+    #[test]
+    fn test_resolved_directory_actually_loads_the_mocks_in_it() {
+        // The end-to-end shape of #84: resolve, then load, and get mocks.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("get_users.json"),
+            r#"{"method":"GET","path":"/users","status":200,"response":{"users":[]}}"#,
+        )
+        .unwrap();
+
+        let resolved = resolve_mocks_dir_from(Some(dir.path().display().to_string()), |p| {
+            Path::new(p).exists()
+        });
+        assert!(resolved.exists);
+
+        let result = load_mocks_map(&resolved.path);
+        assert_eq!(result.errors, 0);
+        assert!(result.mocks.contains_key("GET:/users"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,9 @@ fn run_import(args: &[String]) -> i32 {
                 println!("{}", path.display());
             }
             println!("✅ Generated {} mock file(s)", written.len());
+            if let Some(out_dir) = written.first().and_then(|p| p.parent()) {
+                print_serve_hint(out_dir);
+            }
             0
         }
         Err(openapi::ImportError::Usage(message)) => {
@@ -65,6 +68,36 @@ fn run_import(args: &[String]) -> i32 {
     }
 }
 
+/// Tell the operator how to make the server serve what the importer just
+/// wrote.
+///
+/// The default output directory sits under `./mocks`, which the server reads
+/// by default on a local run — but not when it resolves the Docker mount or a
+/// directory named by `MIMIC_MOCKS_DIR`, and not when `--out` pointed
+/// somewhere else entirely. Rather than assume, this prints whichever of the
+/// two statements is true right now.
+fn print_serve_hint(out_dir: &std::path::Path) {
+    let resolved = loader::resolve_mocks_dir();
+    let already_served = std::path::Path::new(&resolved.path)
+        .canonicalize()
+        .ok()
+        .zip(out_dir.canonicalize().ok())
+        .is_some_and(|(root, out)| out.starts_with(root));
+
+    if already_served {
+        println!(
+            "   {} is already the directory Mimic reads — start it with: mimic",
+            resolved.path
+        );
+    } else {
+        println!(
+            "   Serve them with: {}={} mimic",
+            loader::MOCKS_DIR_ENV,
+            out_dir.display()
+        );
+    }
+}
+
 /// Initializes logging, loads mock configurations, sets up the HTTP server,
 /// and starts listening for incoming requests.
 #[tokio::main]
@@ -74,8 +107,9 @@ async fn run_server() {
 
     info!("🧩 Starting Mimic Mock API Server");
 
-    // Hardcoded mocks directory - Docker volume mount handles the path mapping
-    const MOCKS_DIR: &str = "/app/mocks";
+    // Where mocks are read from: MIMIC_MOCKS_DIR, else /app/mocks when it
+    // exists (the Docker image), else ./mocks.
+    let mocks_dir = loader::resolve_mocks_dir();
 
     // Get port from environment variable
     let port = configured_port();
@@ -84,7 +118,11 @@ async fn run_server() {
     let active_tags = configured_active_tags();
 
     info!("Configuration:");
-    info!("  Mocks directory: {}", MOCKS_DIR);
+    info!(
+        "  Mocks directory: {} ({})",
+        mocks_dir.path,
+        mocks_dir.origin.describe()
+    );
     info!("  Port: {}", port);
     info!("  Max request body: {} bytes", max_body_size());
     match active_tags.as_ref() {
@@ -101,10 +139,13 @@ async fn run_server() {
     }
 
     // Load mock configurations
-    let mocks = load_mocks(MOCKS_DIR);
+    let mocks = load_mocks(&mocks_dir.path);
     {
         let m = mocks.read().await;
         info!("Loaded {} mock(s)", m.len());
+        if m.is_empty() {
+            warn_empty_mock_set(&mocks_dir);
+        }
     }
 
     // Create application state
@@ -113,6 +154,9 @@ async fn run_server() {
     // Spawn background task for hot-reloading mock files
     const RELOAD_INTERVAL_SECS: u64 = 2;
     let reload_mocks = mocks;
+    // The reloader watches the directory that was actually resolved, not a
+    // second copy of the resolution rule that could disagree with it.
+    let reload_dir = mocks_dir.path.clone();
     tokio::spawn(async move {
         let mut interval =
             tokio::time::interval(std::time::Duration::from_secs(RELOAD_INTERVAL_SECS));
@@ -121,9 +165,9 @@ async fn run_server() {
         interval.tick().await;
         loop {
             interval.tick().await;
-            let mocks_dir = MOCKS_DIR;
+            let mocks_dir = reload_dir.clone();
             // Run blocking file I/O off the async runtime to avoid stalling request handling
-            let result = tokio::task::spawn_blocking(move || load_mocks_map(mocks_dir))
+            let result = tokio::task::spawn_blocking(move || load_mocks_map(&mocks_dir))
                 .await
                 .unwrap_or_else(|e| {
                     warn!("Hot reload task panicked: {}", e);
@@ -169,6 +213,30 @@ async fn run_server() {
     axum::serve(listener, app).await.unwrap_or_else(|e| {
         panic!("Server error: {}", e);
     });
+}
+
+/// Explain a startup that registered no mocks at all.
+///
+/// A server answering `404 mock not found` for everything is indistinguishable
+/// from a server that loaded fine, so the two ways of getting there are named
+/// separately: the directory isn't there, or it is there and holds no mock
+/// files. Previously both produced the same near-silence.
+fn warn_empty_mock_set(dir: &loader::ResolvedMocksDir) {
+    if !dir.exists {
+        warn!(
+            "No mocks loaded: '{}' does not exist. Point Mimic at your mocks with {}=<dir>, \
+             or create '{}' next to the working directory.",
+            dir.path,
+            loader::MOCKS_DIR_ENV,
+            dir.path
+        );
+    } else {
+        warn!(
+            "No mocks loaded: '{}' exists but contains no readable *.json mock files \
+             (subdirectories are searched too). Every request will answer 404 mock not found.",
+            dir.path
+        );
+    }
 }
 
 /// Build the mock map a hot-reload cycle should install, given what's


### PR DESCRIPTION
**Stack 2/6** — based on #92. Review the [top commit only](https://github.com/ragilhadi/mimic/pull/93/commits).

---

`run_server` held `const MOCKS_DIR: &str = "/app/mocks"`. Every way of running Mimic other than the Docker image — `cargo run`, `make dev`, an installed binary, a release build — loaded **zero** mocks and answered `404 mock not found` for everything, while the README said `./mocks` worked locally and the OpenAPI importer defaulted to writing into it.

## Resolution is now a rule

`loader::resolve_mocks_dir`, in order:

1. **`MIMIC_MOCKS_DIR`**, used verbatim — a path that doesn't exist is reported as missing rather than silently swapped for a default, so a typo can't masquerade as an empty directory.
2. **`/app/mocks` when it exists.** That's the Docker image, whose volume mount creates it, so every published `docker run -v ./mocks:/app/mocks` resolves precisely where it did before.
3. **`./mocks`** otherwise.

## Saying which failure happened

Startup logs the directory it resolved *and how it got there*, and a run that registers no mocks now distinguishes the two causes — which were previously equally silent, and which is what made the original bug so hard to read:

```
INFO mimic:   Mocks directory: ./mocks (default, relative to the working directory)
INFO mimic: Loaded 31 mock(s)
```

```
WARN mimic: No mocks loaded: './mocks' exists but contains no readable *.json mock files …
WARN mimic: No mocks loaded: '/typo/mocks' does not exist. Point Mimic at your mocks with MIMIC_MOCKS_DIR=<dir> …
```

## Also

- **Hot reload** watches `mocks_dir.path` rather than a second copy of the constant, so the reloader can't drift from what was loaded at startup.
- **The importer** needed no default change: `./mocks/generated` sits inside the `./mocks` the server now falls back to, so `mimic import-openapi ./spec.yaml && mimic` works end to end. When `--out` points outside the resolved directory, it prints the exact `MIMIC_MOCKS_DIR=… mimic` command instead.
- **The Dockerfile** sets `MIMIC_MOCKS_DIR=/app/mocks` explicitly, so the image's contract is stated rather than inferred from a probe.
- README, `.env.example`, and `agents.md` updated; the README no longer claims `./mocks` works locally without it being true.

## Tests

Seven new tests over the resolution rule, with the environment and filesystem injected so nothing mutates a process-wide variable other tests share: Docker default preserved, local fallback, missing-everywhere fallback, env var wins, env var honored when absent, trimming and empty-means-unset, and an end-to-end resolve-then-load.

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)