### PR TITLE
fix: load mocks in sorted order and key per-mock state by identity (#86)

### DIFF
--- a/ADVANCED_MATCHING.md
+++ b/ADVANCED_MATCHING.md
@@ -353,11 +353,16 @@ order:
 1. **More literal path segments.** `/users/:id` (one literal segment) beats
    `/{resource}/:id` (none) for `GET /users/42`.
 2. **Lower registered `METHOD:path` key**, compared lexicographically.
-3. **Earlier position** among mocks sharing that key.
+3. **Earlier position** among mocks sharing that key — which, since mock files
+   load depth-first in alphabetical order by full path, means the mock whose
+   file name sorts first. `mocks/a_dup.json` beats `mocks/z_dup.json`, and
+   `mocks/advanced/x.json` beats `mocks/b.json` because `advanced` sorts before
+   `b`.
 
 The result is a pure function of the loaded mock set: the same request always
 resolves to the same mock across repeated calls, server restarts, and hot
-reloads.
+reloads — and across filesystems, which is why load order is sorted rather than
+left to `readdir`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,27 @@ applied and how many were carried forward.
 Deletions still take effect normally: on a clean cycle (no parse errors) the
 mock set is replaced outright, so removing a file removes its route.
 
+#### What happens to sequence state across a reload
+
+Sequence positions and hit counts belong to **the mock's file**, not to its
+position in the list of mocks sharing a `METHOD:path`. Across a reload:
+
+- **Editing a file** — including editing its `sequence` — leaves that mock's
+  position and hit count where they were. Reset explicitly with
+  `POST /admin/sequences/reset` when you want a clean run.
+- **Adding a mock** under a `METHOD:path` that already has one does not disturb
+  the existing mock's counters, whichever order the two files sort in.
+- **Deleting a file** drops its counters. They are not carried over to whatever
+  is loaded next.
+- **A file that stops parsing** keeps both its route and its counters, since
+  its last-known-good response is still being served.
+
+Mock files load in a fixed order — depth-first, alphabetical by full path — so
+which of several mocks registered for the same `METHOD:path` wins a tie is a
+function of their file names and nothing else. It does not vary between
+filesystems, between a fresh clone and a rebuilt image, or after an unrelated
+file is added to the directory.
+
 ---
 
 ## 📁 Mock Examples

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -4,8 +4,8 @@ use crate::matcher::{
 };
 use crate::template::{render_response, TemplateContext};
 use crate::types::{
-    is_sensitive_header, parse_active_tags, ActiveTags, MockConfig, MockStore, RequestLog,
-    RequestRecord, SequenceCounters, SequenceStep,
+    is_sensitive_header, parse_active_tags, ActiveTags, MockConfig, MockIdentity, MockStore,
+    RequestLog, RequestRecord, SequenceCounters, SequenceStep,
 };
 use axum::{
     body::Body,
@@ -23,9 +23,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
-/// Per-mock hit counts, keyed like the sequence counters ("METHOD:/path#idx")
-/// so one mock among several registered for a path can be told from the rest.
-pub type MockHits = Arc<tokio::sync::RwLock<HashMap<String, u64>>>;
+/// Per-mock hit counts, keyed like the sequence counters — by the mock's
+/// stable [`MockIdentity`] — so one mock among several registered for a path
+/// can be told from the rest, and keeps its count across a hot reload.
+pub type MockHits = Arc<tokio::sync::RwLock<HashMap<MockIdentity, u64>>>;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -310,15 +311,23 @@ pub async fn handle_request(
             // `/users/:id`), if any, become available to templating below.
             context.path_params = path_params;
 
+            // The identity this mock's cross-request state hangs off: its
+            // declared key plus the file it came from, not its position in a
+            // vector that hot reload rebuilds every two seconds. Computed once
+            // and used for both the sequence counter and the hit count, which
+            // must agree on which mock they're talking about.
+            //
+            // Keying by the *declared* path (`mock_key`) rather than the
+            // concrete request path is what makes a pattern mock like
+            // `/users/:id` advance a single shared sequence regardless of which
+            // id was requested.
+            let identity = MockIdentity::of(&mock, &mock_key, index);
+
             // Resolve the response: sequence step if configured, top-level otherwise.
             // An empty sequence array falls back to the top-level status/response.
-            // The counter is keyed by the mock's declared path (`mock_key`), not the
-            // concrete request path, so a pattern mock like `/users/:id` advances a
-            // single shared sequence regardless of which id was requested.
             let (status_u16, response, delay_ms) = match mock.sequence.as_deref() {
                 Some(steps) if !steps.is_empty() => {
-                    let counter_key = format!("{}#{}", mock_key, index);
-                    advance_sequence(&state.sequence_counters, &counter_key, steps).await
+                    advance_sequence(&state.sequence_counters, &identity, steps).await
                 }
                 _ => (mock.status, mock.response.clone(), None),
             };
@@ -347,9 +356,8 @@ pub async fn handle_request(
             // same way as its sequence counter so several mocks sharing a path
             // stay distinguishable.
             {
-                let hit_key = format!("{}#{}", mock_key, index);
                 let mut hits = state.mock_hits.write().await;
-                *hits.entry(hit_key).or_insert(0) += 1;
+                *hits.entry(identity).or_insert(0) += 1;
             }
 
             // Serialize the response once: the same bytes are both sent to the
@@ -735,7 +743,7 @@ pub async fn list_mocks(State(state): State<AppState>) -> Json<serde_json::Value
     for key in keys {
         for (index, mock) in mocks[key].iter().enumerate() {
             let hit_count = hits
-                .get(&format!("{}#{}", key, index))
+                .get(&MockIdentity::of(mock, key, index))
                 .copied()
                 .unwrap_or(0);
             entries.push(describe_mock_entry(
@@ -763,33 +771,37 @@ pub async fn list_sequences(State(state): State<AppState>) -> Json<serde_json::V
     let counters = state.sequence_counters.read().await;
     let mocks = state.mocks.read().await;
 
-    let mut keys: Vec<&String> = counters.keys().collect();
-    keys.sort();
+    let mut identities: Vec<&MockIdentity> = counters.keys().collect();
+    identities.sort();
 
-    let sequences: Vec<serde_json::Value> = keys
+    let sequences: Vec<serde_json::Value> = identities
         .into_iter()
-        .map(|counter_key| {
-            // Counter keys look like "METHOD:/path#idx"
-            let (mock_key, index) = counter_key
-                .rsplit_once('#')
-                .map_or((counter_key.as_str(), None), |(k, i)| {
-                    (k, i.parse::<usize>().ok())
-                });
-            let (method, path) = mock_key
-                .split_once(':')
-                .map_or(("", mock_key), |(m, p)| (m, p));
-
-            let mock = index
-                .and_then(|i| mocks.get(mock_key).and_then(|list| list.get(i)))
+        .map(|identity| {
+            // The mock the counter belongs to, found by identity rather than
+            // by position — a counter outlives a reload, a position doesn't.
+            // A counter whose mock is gone still renders, with a null `total`.
+            let mock = mocks
+                .get(&identity.key)
+                .and_then(|list| {
+                    list.iter().enumerate().find(|(index, mock)| {
+                        MockIdentity::of(mock, &identity.key, *index) == *identity
+                    })
+                })
+                .map(|(_, mock)| mock)
                 .filter(|mock| mock.sequence.is_some());
 
             json!({
-                "key": counter_key,
-                "method": method,
-                "path": path,
-                "step": counters[counter_key],
+                "key": identity.label(),
+                "method": identity.method(),
+                "path": identity.path(),
+                "step": counters[identity],
                 "total": mock.and_then(|m| m.sequence.as_ref().map(|s| s.len())),
-                "source": mock.and_then(|m| m.source.clone()),
+                // The mock's own `source` where it's still loaded, falling back
+                // to the file the identity was minted from so a counter left
+                // over from a deleted mock still names the file it came from.
+                "source": mock
+                    .and_then(|m| m.source.clone())
+                    .or_else(|| identity.source().map(str::to_string)),
             })
         })
         .collect();
@@ -964,11 +976,11 @@ fn assemble_response(status: StatusCode, header_map: HeaderMap, body: String) ->
 /// The write lock is held only for the map lookup + clone, never across an await.
 async fn advance_sequence(
     counters: &SequenceCounters,
-    key: &str,
+    identity: &MockIdentity,
     steps: &[SequenceStep],
 ) -> (u16, serde_json::Value, Option<u64>) {
     let mut map = counters.write().await;
-    let count = map.entry(key.to_string()).or_insert(0);
+    let count = map.entry(identity.clone()).or_insert(0);
     // Clamp so the last step keeps repeating once the sequence is exhausted
     let idx = (*count).min(steps.len() - 1);
     let step = &steps[idx];
@@ -991,14 +1003,7 @@ pub async fn reset_sequences(
     let removed = match filter.path {
         Some(ref p) => {
             let before = counters.len();
-            // Counter keys look like "METHOD:/path#idx" — compare the path part only
-            counters.retain(|key, _| {
-                let after_method = key.split_once(':').map_or("", |(_, rest)| rest);
-                let path_part = after_method
-                    .rsplit_once('#')
-                    .map_or(after_method, |(path_part, _)| path_part);
-                path_part != p
-            });
+            counters.retain(|identity, _| identity.path() != p);
             before - counters.len()
         }
         None => {
@@ -3616,7 +3621,9 @@ mod tests {
         let body = list_sequences(State(state)).await.0;
         assert_eq!(body["count"], 1);
         let seq = &body["sequences"][0];
-        assert_eq!(seq["key"], "POST:/submit#0");
+        // The counter is named after the file it belongs to, not its position
+        // in a bucket hot reload rebuilds every two seconds.
+        assert_eq!(seq["key"], "POST:/submit @ mocks/post_submit.json");
         assert_eq!(seq["method"], "POST");
         assert_eq!(seq["path"], "/submit");
         assert_eq!(seq["step"], 2);
@@ -3646,7 +3653,13 @@ mod tests {
         let state = dash_state(vec![]);
         {
             let mut counters = state.sequence_counters.write().await;
-            counters.insert("POST:/gone#0".to_string(), 4);
+            counters.insert(
+                MockIdentity {
+                    key: "POST:/gone".to_string(),
+                    origin: crate::types::MockOrigin::Source("mocks/gone.json".to_string()),
+                },
+                4,
+            );
         }
 
         let body = list_sequences(State(state)).await.0;
@@ -4447,10 +4460,15 @@ mod scenario_tests {
         request(&state, Method::POST, "/checkout").await;
 
         let hits = state.mock_hits.read().await;
-        // Index 1 is the error-scenario mock's real position in its bucket;
-        // filtering must not renumber the mocks around it.
-        assert_eq!(hits.get("POST:/checkout#1").copied(), Some(1));
-        assert_eq!(hits.get("POST:/checkout#0").copied(), None);
+        // These mocks are built in-process with no `source`, so their identity
+        // falls back to bucket position. Index 1 is the error-scenario mock's
+        // real position; filtering must not renumber the mocks around it.
+        let at = |index: usize| MockIdentity {
+            key: "POST:/checkout".to_string(),
+            origin: crate::types::MockOrigin::Position(index),
+        };
+        assert_eq!(hits.get(&at(1)).copied(), Some(1));
+        assert_eq!(hits.get(&at(0)).copied(), None);
     }
 
     #[tokio::test]

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -176,47 +176,60 @@ pub fn load_mocks(path: &str) -> MockStore {
 }
 
 /// Recursively collects and loads all JSON mock files from a directory tree.
+///
+/// Entries are **sorted by path before anything is loaded**. `fs::read_dir`
+/// guarantees no ordering — it differs between ext4 and NTFS, and can change
+/// on the same machine when unrelated files are added or removed — and two
+/// things downstream read the resulting order as if it meant something: which
+/// of several mocks sharing a `METHOD:path` wins a tie in `find_matching_mock`,
+/// and (before mocks were given a stable identity) which mock owned which
+/// counter. Sorting makes bucket order a pure function of the file names:
+/// depth-first, alphabetical by full path, with a subdirectory visited at the
+/// point its own name sorts in.
 fn collect_json_files(
     dir: &Path,
     mocks: &mut HashMap<String, Vec<MockConfig>>,
     errors: &mut usize,
 ) {
-    match fs::read_dir(dir) {
-        Ok(entries) => {
-            for entry in entries.flatten() {
-                let entry_path = entry.path();
-                if entry_path.is_dir() {
-                    collect_json_files(&entry_path, mocks, errors);
-                } else if entry_path.is_file()
-                    && entry_path.extension().and_then(|s| s.to_str()) == Some("json")
-                {
-                    match load_single_mock(&entry_path) {
-                        Ok(mock) => {
-                            let key = create_mock_key(&mock.method, &mock.path);
-                            debug!("Loaded mock: {} -> {}", key, entry_path.display());
-                            let entry = mocks.entry(key).or_default();
-                            if !entry.is_empty() {
-                                warn!(
-                                    "Multiple mocks registered for {} {}: {} total (file: {})",
-                                    mock.method,
-                                    mock.path,
-                                    entry.len() + 1,
-                                    entry_path.display()
-                                );
-                            }
-                            entry.push(mock);
-                        }
-                        Err(e) => {
-                            warn!("Failed to load mock file {}: {}", entry_path.display(), e);
-                            *errors += 1;
-                        }
-                    }
-                }
-            }
-        }
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
         Err(e) => {
             error!("Failed to read directory {}: {}", dir.display(), e);
             *errors += 1;
+            return;
+        }
+    };
+
+    let mut paths: Vec<_> = entries.flatten().map(|entry| entry.path()).collect();
+    paths.sort();
+
+    for entry_path in paths {
+        if entry_path.is_dir() {
+            collect_json_files(&entry_path, mocks, errors);
+        } else if entry_path.is_file()
+            && entry_path.extension().and_then(|s| s.to_str()) == Some("json")
+        {
+            match load_single_mock(&entry_path) {
+                Ok(mock) => {
+                    let key = create_mock_key(&mock.method, &mock.path);
+                    debug!("Loaded mock: {} -> {}", key, entry_path.display());
+                    let entry = mocks.entry(key).or_default();
+                    if !entry.is_empty() {
+                        warn!(
+                            "Multiple mocks registered for {} {}: {} total (file: {})",
+                            mock.method,
+                            mock.path,
+                            entry.len() + 1,
+                            entry_path.display()
+                        );
+                    }
+                    entry.push(mock);
+                }
+                Err(e) => {
+                    warn!("Failed to load mock file {}: {}", entry_path.display(), e);
+                    *errors += 1;
+                }
+            }
         }
     }
 }
@@ -696,6 +709,81 @@ mod tests {
             result.mocks["POST:/login"][0].source.as_deref(),
             Some(file.to_str().unwrap())
         );
+    }
+
+    // ------------------------------------------------------------------
+    // Deterministic load order (#86)
+    // ------------------------------------------------------------------
+
+    /// Write files in the given order and return the bucket for `GET:/dup`,
+    /// as the markers its mocks carry.
+    fn load_dup_bucket_written_in(order: &[&str]) -> Vec<String> {
+        let dir = TempDir::new().unwrap();
+        for name in order {
+            fs::write(
+                dir.path().join(format!("{}.json", name)),
+                format!(
+                    r#"{{"method":"GET","path":"/dup","status":200,"response":{{"from":"{}"}}}}"#,
+                    name
+                ),
+            )
+            .unwrap();
+        }
+
+        let result = load_mocks_map(dir.path().to_str().unwrap());
+        result.mocks["GET:/dup"]
+            .iter()
+            .map(|mock| mock.response["from"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn test_bucket_order_does_not_depend_on_the_order_files_were_created() {
+        // `fs::read_dir` guarantees no ordering, and `find_matching_mock`'s
+        // final tie-break is bucket position — so without sorting, which of
+        // two identical mocks wins is decided by the filesystem, and can flip
+        // on a fresh clone or a rebuilt image with no diff to point at.
+        let forwards = load_dup_bucket_written_in(&["a", "m", "z"]);
+        let backwards = load_dup_bucket_written_in(&["z", "m", "a"]);
+        let shuffled = load_dup_bucket_written_in(&["m", "z", "a"]);
+
+        assert_eq!(forwards, vec!["a", "m", "z"]);
+        assert_eq!(forwards, backwards);
+        assert_eq!(forwards, shuffled);
+    }
+
+    #[test]
+    fn test_nested_directories_load_in_a_fixed_alphabetical_order() {
+        // The rule covers the interleaving of a directory's own files with its
+        // subdirectories', not just the files at one level.
+        let dir = TempDir::new().unwrap();
+        let sub = dir.path().join("advanced");
+        fs::create_dir(&sub).unwrap();
+
+        for (path, marker) in [
+            (dir.path().join("b_top.json"), "b_top"),
+            (dir.path().join("z_top.json"), "z_top"),
+            (sub.join("nested.json"), "advanced/nested"),
+        ] {
+            fs::write(
+                &path,
+                format!(
+                    r#"{{"method":"GET","path":"/dup","status":200,"response":{{"from":"{}"}}}}"#,
+                    marker
+                ),
+            )
+            .unwrap();
+        }
+
+        let result = load_mocks_map(dir.path().to_str().unwrap());
+        let order: Vec<&str> = result.mocks["GET:/dup"]
+            .iter()
+            .map(|mock| mock.response["from"].as_str().unwrap())
+            .collect();
+
+        // "advanced" sorts before "b_top.json" and "z_top.json", and is
+        // recursed into at the point its own name sorts in.
+        assert_eq!(order, vec!["advanced/nested", "b_top", "z_top"]);
     }
 
     // ------------------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use handler::{
     max_log_entries, reset_sequences, set_scenario, AppState,
 };
 use loader::{load_mocks, load_mocks_map};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use tower_http::trace::TraceLayer;
 use tracing::{debug, info, warn};
@@ -157,6 +157,9 @@ async fn run_server() {
     // The reloader watches the directory that was actually resolved, not a
     // second copy of the resolution rule that could disagree with it.
     let reload_dir = mocks_dir.path.clone();
+    // Per-mock state the reloader has to reconcile against the new mock set.
+    let reload_counters = state.sequence_counters.clone();
+    let reload_hits = state.mock_hits.clone();
     tokio::spawn(async move {
         let mut interval =
             tokio::time::interval(std::time::Duration::from_secs(RELOAD_INTERVAL_SECS));
@@ -176,21 +179,29 @@ async fn run_server() {
                         errors: 1,
                     }
                 });
-            let mut store = reload_mocks.write().await;
-            let old_len = store.len();
-            *store = apply_reload(&store, result);
-            let new_len = store.len();
-            if old_len != new_len {
-                info!(
-                    "🔄 Hot reload: mocks updated ({} -> {} endpoint(s))",
-                    old_len, new_len
-                );
-            } else {
-                debug!(
-                    "🔄 Hot reload: mocks reloaded ({} endpoint(s), no changes)",
-                    new_len
-                );
-            }
+            // The mock lock is released before the counter locks are taken:
+            // `list_sequences` reads counters and then mocks, so holding both
+            // in the opposite order here would be a deadlock waiting to happen.
+            let live = {
+                let mut store = reload_mocks.write().await;
+                let old_len = store.len();
+                *store = apply_reload(&store, result);
+                let new_len = store.len();
+                if old_len != new_len {
+                    info!(
+                        "🔄 Hot reload: mocks updated ({} -> {} endpoint(s))",
+                        old_len, new_len
+                    );
+                } else {
+                    debug!(
+                        "🔄 Hot reload: mocks reloaded ({} endpoint(s), no changes)",
+                        new_len
+                    );
+                }
+                live_identities(&store)
+            };
+
+            prune_stale_state(&reload_counters, &reload_hits, &live).await;
         }
     });
 
@@ -213,6 +224,56 @@ async fn run_server() {
     axum::serve(listener, app).await.unwrap_or_else(|e| {
         panic!("Server error: {}", e);
     });
+}
+
+/// Every mock identity a mock map currently registers.
+fn live_identities(
+    store: &HashMap<String, Vec<types::MockConfig>>,
+) -> HashSet<types::MockIdentity> {
+    store
+        .iter()
+        .flat_map(|(key, list)| {
+            list.iter()
+                .enumerate()
+                .map(move |(index, mock)| types::MockIdentity::of(mock, key, index))
+        })
+        .collect()
+}
+
+/// Drop per-mock state belonging to mocks the latest reload no longer loads.
+///
+/// A counter for a deleted mock used to be left behind indefinitely: harmless
+/// on its own, except that its key was a *position*, so the next mock to land
+/// in that slot inherited a half-consumed sequence and someone else's hit
+/// count. Identities are stable now, which stops the misattribution — but an
+/// orphan still has to go, or `/admin/sequences` accumulates rows for files
+/// that no longer exist and `/admin/mocks` reports totals nothing can explain.
+///
+/// A mock that merely stops parsing keeps its state: `apply_reload` carries
+/// its last-known-good route forward, so it's still registered and still live.
+async fn prune_stale_state(
+    counters: &types::SequenceCounters,
+    hits: &handler::MockHits,
+    live: &HashSet<types::MockIdentity>,
+) {
+    let dropped = {
+        let mut counters = counters.write().await;
+        let before = counters.len();
+        counters.retain(|identity, _| live.contains(identity));
+        before - counters.len()
+    };
+
+    {
+        let mut hits = hits.write().await;
+        hits.retain(|identity, _| live.contains(identity));
+    }
+
+    if dropped > 0 {
+        info!(
+            "🔄 Hot reload: dropped {} sequence counter(s) for mocks that are no longer loaded",
+            dropped
+        );
+    }
 }
 
 /// Explain a startup that registered no mocks at all.
@@ -685,6 +746,175 @@ mod tests {
 
         assert_eq!(next["GET:/broken"][0].response["source"], "last-good");
         assert_eq!(next["GET:/ok"][0].response["source"], "ok-updated");
+    }
+
+    // ------------------------------------------------------------------
+    // Per-mock state survives a reload that reorders the bucket (#86)
+    // ------------------------------------------------------------------
+
+    /// A mock for `POST /orders` whose three steps announce which file they
+    /// came from, so a step served by the wrong mock is visible in the body.
+    fn sequenced_orders_mock(who: &str) -> String {
+        let step = |n: u8| {
+            format!(
+                r#"{{"status":200,"response":{{"who":"{}","step":{}}}}}"#,
+                who, n
+            )
+        };
+        format!(
+            r#"{{"method":"POST","path":"/orders","status":200,"response":{{}},
+                 "sequence":[{},{},{}]}}"#,
+            step(1),
+            step(2),
+            step(3)
+        )
+    }
+
+    async fn post_orders(state: &AppState) -> serde_json::Value {
+        let response = handle_request(
+            axum::http::Method::POST,
+            "/orders".parse().unwrap(),
+            axum::http::HeaderMap::new(),
+            axum::extract::State(state.clone()),
+            Body::empty(),
+        )
+        .await;
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    /// Run one hot-reload cycle against a directory, exactly as the background
+    /// task does: reload, install, then reconcile per-mock state.
+    async fn reload_cycle(state: &AppState, store: &types::MockStore, dir: &std::path::Path) {
+        let result = load_mocks_map(dir.to_str().unwrap());
+        let live = {
+            let mut current = store.write().await;
+            *current = apply_reload(&current, result);
+            live_identities(&current)
+        };
+        prune_stale_state(&state.sequence_counters, &state.mock_hits, &live).await;
+    }
+
+    #[tokio::test]
+    async fn test_adding_a_sibling_mock_does_not_move_an_existing_sequence() {
+        // The issue's repro: a sequence half-consumed by one mock must not be
+        // adopted by a file that lands ahead of it in the bucket.
+        let dir = tempfile::tempdir().unwrap();
+        write_mock(dir.path(), "b_orders.json", &sequenced_orders_mock("b"));
+
+        let store = load_mocks(dir.path().to_str().unwrap());
+        let state = AppState::new(store.clone());
+
+        assert_eq!(post_orders(&state).await["step"], 1);
+        assert_eq!(post_orders(&state).await["step"], 2);
+
+        // A teammate adds a second scenario for the same endpoint. Its name
+        // sorts first, so it takes bucket position 0 — the position the
+        // half-consumed counter used to be keyed by.
+        write_mock(dir.path(), "a_orders.json", &sequenced_orders_mock("a"));
+        reload_cycle(&state, &store, dir.path()).await;
+
+        // The new mock wins the tie-break and serves. It must start at its own
+        // first step; keyed by position it would have inherited the other
+        // mock's two calls and served step 3 on its first-ever request.
+        let served = post_orders(&state).await;
+        assert_eq!(served["who"], "a");
+        assert_eq!(
+            served["step"], 1,
+            "a fresh mock must start its own sequence"
+        );
+
+        // And the original mock's position is untouched, not restarted.
+        let counters = state.sequence_counters.read().await;
+        let step_of = |file: &str| {
+            counters
+                .iter()
+                .find(|(identity, _)| {
+                    identity
+                        .source()
+                        .is_some_and(|source| source.ends_with(file))
+                })
+                .map(|(_, step)| *step)
+        };
+        assert_eq!(step_of("b_orders.json"), Some(2));
+        assert_eq!(step_of("a_orders.json"), Some(1));
+    }
+
+    #[tokio::test]
+    async fn test_hit_counts_stay_with_their_mock_across_a_reload() {
+        let dir = tempfile::tempdir().unwrap();
+        write_mock(
+            dir.path(),
+            "b_orders.json",
+            r#"{"method":"POST","path":"/orders","status":200,"response":{"who":"b"}}"#,
+        );
+
+        let store = load_mocks(dir.path().to_str().unwrap());
+        let state = AppState::new(store.clone());
+        post_orders(&state).await;
+        post_orders(&state).await;
+
+        write_mock(
+            dir.path(),
+            "a_orders.json",
+            r#"{"method":"POST","path":"/orders","status":200,"response":{"who":"a"}}"#,
+        );
+        reload_cycle(&state, &store, dir.path()).await;
+
+        let hits = state.mock_hits.read().await;
+        let hits_for = |file: &str| {
+            hits.iter()
+                .find(|(identity, _)| identity.source().is_some_and(|s| s.ends_with(file)))
+                .map(|(_, count)| *count)
+        };
+        assert_eq!(hits_for("b_orders.json"), Some(2));
+        assert_eq!(
+            hits_for("a_orders.json"),
+            None,
+            "a mock that has served nothing must not inherit another's count"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reload_drops_counters_for_a_deleted_mock() {
+        let dir = tempfile::tempdir().unwrap();
+        write_mock(dir.path(), "orders.json", &sequenced_orders_mock("b"));
+
+        let store = load_mocks(dir.path().to_str().unwrap());
+        let state = AppState::new(store.clone());
+        post_orders(&state).await;
+        assert_eq!(state.sequence_counters.read().await.len(), 1);
+
+        std::fs::remove_file(dir.path().join("orders.json")).unwrap();
+        reload_cycle(&state, &store, dir.path()).await;
+
+        assert!(
+            state.sequence_counters.read().await.is_empty(),
+            "an orphaned counter must be dropped, not left for the next mock to adopt"
+        );
+        assert!(state.mock_hits.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_a_file_that_stops_parsing_keeps_its_counter() {
+        // `apply_reload` carries a broken file's last-known-good route
+        // forward, so the mock is still loaded and still serving — pruning
+        // must not treat "failed to parse this cycle" as "deleted".
+        let dir = tempfile::tempdir().unwrap();
+        write_mock(dir.path(), "orders.json", &sequenced_orders_mock("b"));
+
+        let store = load_mocks(dir.path().to_str().unwrap());
+        let state = AppState::new(store.clone());
+        assert_eq!(post_orders(&state).await["step"], 1);
+
+        write_mock(dir.path(), "orders.json", "{ mid-save");
+        reload_cycle(&state, &store, dir.path()).await;
+
+        assert_eq!(
+            post_orders(&state).await["step"],
+            2,
+            "the sequence should resume, not restart, while the file is being fixed"
+        );
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -333,8 +333,89 @@ where
     (!parsed.is_empty()).then_some(parsed)
 }
 
-/// Per-mock sequence call counters, keyed by "METHOD:/path#<index>"
-pub type SequenceCounters = Arc<RwLock<HashMap<String, usize>>>;
+// ============================================================================
+// Stable Mock Identity
+// ============================================================================
+
+/// What tells one mock apart from the others registered under the same
+/// `METHOD:/path`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum MockOrigin {
+    /// The file the mock was loaded from. Stable for as long as the file is,
+    /// which is exactly the lifetime the state keyed by it should have.
+    Source(String),
+    /// Position in the bucket, for a mock built in-process — tests, generated
+    /// fixtures — with no file behind it. Carries the old semantics for the
+    /// only case that can't do better.
+    Position(usize),
+}
+
+/// A stable identity for one loaded mock.
+///
+/// State that has to outlive a hot reload — sequence positions, hit counts —
+/// is keyed by this rather than by a mock's position in its bucket. The mock
+/// map is rebuilt from scratch every reload cycle, so a position is a
+/// statement about *this* cycle's vector: add a file that sorts earlier under
+/// the same `METHOD:/path` and position 0 silently starts naming a different
+/// mock, handing it a half-consumed sequence and another mock's hit count.
+///
+/// The file path is the stable half. A mock keeps its identity when a sibling
+/// appears or disappears, and loses it — correctly — when its own file is
+/// renamed or deleted.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct MockIdentity {
+    /// The registration key, `METHOD:/declared/path`. For a pattern mock this
+    /// is the declared template (`GET:/users/:id`), not the concrete request
+    /// path, so one sequence is shared across every id — as it always was.
+    pub key: String,
+    pub origin: MockOrigin,
+}
+
+impl MockIdentity {
+    /// The identity of `mock`, registered under `key` at position `index`.
+    pub fn of(mock: &MockConfig, key: &str, index: usize) -> Self {
+        Self {
+            key: key.to_string(),
+            origin: match mock.source.as_deref() {
+                Some(source) => MockOrigin::Source(source.to_string()),
+                None => MockOrigin::Position(index),
+            },
+        }
+    }
+
+    /// The method half of the registration key.
+    pub fn method(&self) -> &str {
+        self.key.split_once(':').map_or("", |(method, _)| method)
+    }
+
+    /// The declared path half of the registration key.
+    pub fn path(&self) -> &str {
+        self.key
+            .split_once(':')
+            .map_or(self.key.as_str(), |(_, path)| path)
+    }
+
+    /// The file this mock came from, if it came from one.
+    pub fn source(&self) -> Option<&str> {
+        match &self.origin {
+            MockOrigin::Source(source) => Some(source),
+            MockOrigin::Position(_) => None,
+        }
+    }
+
+    /// A human-readable rendering for the admin API, e.g.
+    /// `POST:/orders @ mocks/orders_flow.json`.
+    pub fn label(&self) -> String {
+        match &self.origin {
+            MockOrigin::Source(source) => format!("{} @ {}", self.key, source),
+            MockOrigin::Position(index) => format!("{}#{}", self.key, index),
+        }
+    }
+}
+
+/// Per-mock sequence call counters, keyed by a mock's stable identity so a
+/// hot reload can't hand one mock's position to another.
+pub type SequenceCounters = Arc<RwLock<HashMap<MockIdentity, usize>>>;
 
 // ============================================================================
 // Request History Types


### PR DESCRIPTION
**Stack 4/6** — based on #94. Review the [top commit only](https://github.com/ragilhadi/mimic/pull/95/commits).

---

`collect_json_files` walked `fs::read_dir`, which guarantees no ordering, and two things downstream read that order as if it meant something.

## 1. Which mock wins

`find_matching_mock`'s final tie-break is bucket position, so for two equally-scoring mocks on one `METHOD:path` the winner was decided by the filesystem — differing between ext4 and NTFS, and able to flip on the same machine after an unrelated file was added. The comment above that sort claims the winner is *"a pure function of the mock set, never of `HashMap` iteration order"*. It now is, because the **input** to the sort is fixed too.

Directory entries are sorted by path before anything loads: depth-first, alphabetical by full path, with a subdirectory visited at the point its own name sorts in. #55 made the sort deterministic; this makes what goes into it deterministic.

## 2. Which mock owns a counter

`sequence_counters` and `mock_hits` were keyed `"METHOD:/path#<index>"` — a *position* in a vector the hot reloader rebuilds from scratch every two seconds — while the maps themselves survive the reload. Adding a second mock for an existing `METHOD:path` moved `#0` onto a different mock, handing it a half-consumed sequence and another mock's hits. Deleting one left an orphan for whatever occupied that index next to adopt.

Both maps are now keyed by **`MockIdentity`** — the registration key plus the file the mock was loaded from, falling back to position only for mocks built in-process, which have no file to name. A mock keeps its state when a sibling appears or disappears, and loses it exactly when its own file does. `/admin/sequences` and `reset_sequences` read that struct instead of re-parsing a string key on `#` and `:`.

## 3. Reconciliation

Each reload drops counters and hit counts whose identity is no longer loaded, so an orphan can't accumulate. A file that merely stops *parsing* keeps its state — `apply_reload` carries its last-known-good route forward and it is still serving, so "failed to parse this cycle" must not read as "deleted".

> The mocks lock is released before the counter locks are taken. `list_sequences` acquires them in the opposite order, so holding both here would be an ABBA deadlock waiting to happen.

## Tests

- a directory whose files are created in shuffled order (`a,m,z` / `z,m,a` / `m,z,a`) produces the same bucket every time
- nested directories interleave in one fixed alphabetical order
- **the issue's repro**: a sequence on step 2 stays on step 2 when a file that sorts ahead of it appears, and the new mock starts at *its own* step 1 rather than serving step 3 on its first request
- hit counts stay with their mock across the same reload
- a deleted mock's counters are dropped
- a file that stops parsing resumes rather than restarts

## Docs

README's Hot Reload section gains *What happens to sequence state across a reload* (edit / add / delete / stops-parsing, one line each). ADVANCED_MATCHING.md's tie-break list now says which file name wins.

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)