### PR TITLE
fix: name, flag, and free the routes that shadow mocks (#87)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,15 @@ RUST_LOG=info
 # volume mount creates it — and ./mocks otherwise, which is what a local
 # `cargo run` or an installed binary picks up. Subdirectories are searched too.
 # MIMIC_MOCKS_DIR=./mocks
+
+# Routes Mimic answers itself, which a mock therefore cannot serve.
+# Set MIMIC_HEALTH_PATH to an empty value to stop serving the health check and
+# free GET /health for a mock; set it to another path to move it. Likewise
+# MIMIC_ADMIN_PREFIX moves the admin API, and MIMIC_DISABLE_ADMIN=true removes
+# it. Defaults reserve GET /health and the /admin/* endpoints.
+# MIMIC_HEALTH_PATH=/health
+# MIMIC_ADMIN_PREFIX=/admin
+# MIMIC_DISABLE_ADMIN=false
 # Maximum request body size Mimic will buffer, in bytes (default: 10485760 = 10 MB)
 # Requests over this size are rejected with 413 Payload Too Large before the
 # body is buffered.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ MIMIC_MAX_RECORDED_BODY=65536
 # Scenario tags active at startup, comma-separated (default: unset = all
 # mocks matchable). See "Tagged Mock Groups" below.
 MIMIC_ACTIVE_TAGS=happy-path,smoke-test
+
+# Where the health check is served (default: /health). Empty = don't serve it,
+# freeing the path for a mock. See "Reserved endpoints" below.
+MIMIC_HEALTH_PATH=/health
+
+# Prefix the admin API is mounted under (default: /admin).
+MIMIC_ADMIN_PREFIX=/admin
+
+# Switch the admin API off entirely (default: false)
+MIMIC_DISABLE_ADMIN=false
 ```
 
 **Log Levels**:
@@ -190,6 +200,46 @@ INFO mimic: Loaded 31 mock(s)
 - `consume_body` - (Optional) Boolean to control request body consumption (default: `false`)
   - `true` - Consume request body (required for file uploads, multipart/form-data)
   - `false` - Skip body consumption (faster, default behavior)
+
+### Reserved endpoints
+
+Mimic answers a handful of routes itself, and they are matched **ahead of** the
+mock set. A mock declaring one of these loads normally, is listed by
+`GET /admin/mocks`, and then never serves a request:
+
+| Reserved | Method(s) |
+|---|---|
+| `/health` | `GET` |
+| `/admin/dashboard` | `GET` |
+| `/admin/requests` | `GET`, `DELETE` |
+| `/admin/mocks` | `GET` |
+| `/admin/sequences` | `GET` |
+| `/admin/sequences/reset` | `POST` |
+| `/admin/scenario` | `GET`, `POST` |
+
+Only these exact **method + path** pairs are reserved. `POST /health` and
+`GET /admin/users` reach the mock set normally and can be mocked.
+
+A collision is reported rather than left to be discovered:
+
+- the loader warns at startup, and again whenever hot reload introduces one,
+  naming the file — `mocks/health_down.json declares GET /health, which is
+  reserved by Mimic's health check and will never be served`;
+- `GET /admin/mocks` reports the mock with `"reachable": false` and an
+  `unreachable_reason`, and the dashboard shows it as an **unreachable** badge —
+  so a permanent `hits: 0` is distinguishable from "nothing has called it yet".
+
+**If your API genuinely owns these paths**, take them back:
+
+```bash
+MIMIC_HEALTH_PATH= mimic                    # no health check; GET /health is yours
+MIMIC_HEALTH_PATH=/_mimic/health mimic      # or move it out of the way
+MIMIC_ADMIN_PREFIX=/_mimic mimic            # admin API at /_mimic/mocks, etc.
+MIMIC_DISABLE_ADMIN=true mimic              # no admin API at all
+```
+
+Whatever is left reserved is logged at startup, and a freed route is a normal
+mock path from that moment on.
 
 ### Hot Reload
 

--- a/agents.md
+++ b/agents.md
@@ -22,7 +22,8 @@
 - **Purpose:** Route HTTP requests to handlers
 - **Inputs:** HTTP requests on port 8080, `PORT` and `RUST_LOG` env vars
 - **Outputs:** HTTP responses, access logs, health checks
-- **Responsibilities:** Setup routes (`/health`, catch-all), middleware, lifecycle management
+- **Responsibilities:** Setup routes (`/health`, `/admin/*`, catch-all), middleware, lifecycle management
+- **Reserved routes:** `/health` and the admin endpoints are matched ahead of the fallback, so a mock declaring one is loaded but unreachable. `ReservedRoutes` is the single list of those method+path pairs — the router registers from it and `/admin/mocks` flags collisions against it, so the two can't disagree. `MIMIC_HEALTH_PATH`, `MIMIC_ADMIN_PREFIX`, and `MIMIC_DISABLE_ADMIN` move or remove them. Every built-in route carries `.fallback(handle_request)`, so an undeclared method reaches the mock pipeline instead of producing a bare 405.
 
 ### 3. **Matcher Agent** (`src/matcher.rs`)
 - **Purpose:** Find best matching mock using pattern matching, and explain the outcome

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -28,6 +28,153 @@ use tracing::{debug, info, warn};
 /// can be told from the rest, and keeps its count across a hot reload.
 pub type MockHits = Arc<tokio::sync::RwLock<HashMap<MockIdentity, u64>>>;
 
+// ============================================================================
+// Reserved Routes
+// ============================================================================
+
+/// Environment variable moving the admin API off `/admin`.
+pub const ADMIN_PREFIX_ENV: &str = "MIMIC_ADMIN_PREFIX";
+
+/// Environment variable switching the admin API off entirely.
+pub const DISABLE_ADMIN_ENV: &str = "MIMIC_DISABLE_ADMIN";
+
+/// Environment variable moving — or, when empty, removing — the health check.
+pub const HEALTH_PATH_ENV: &str = "MIMIC_HEALTH_PATH";
+
+/// Default path of the health check endpoint.
+pub const DEFAULT_HEALTH_PATH: &str = "/health";
+
+/// Default prefix the admin API is mounted under.
+pub const DEFAULT_ADMIN_PREFIX: &str = "/admin";
+
+/// The paths under the admin prefix, paired with the methods they answer.
+///
+/// This is the list `create_router` registers, and the list a mock is checked
+/// against — one array, so a route can't be reserved in the diagnostic and
+/// unregistered in the router, or the reverse.
+const ADMIN_ROUTES: &[(&str, &[&str])] = &[
+    ("/dashboard", &["GET"]),
+    ("/requests", &["GET", "DELETE"]),
+    ("/mocks", &["GET"]),
+    ("/sequences", &["GET"]),
+    ("/sequences/reset", &["POST"]),
+    ("/scenario", &["GET", "POST"]),
+];
+
+/// The method+path pairs Mimic answers itself, and which a mock therefore
+/// cannot serve.
+///
+/// Explicit routes are matched ahead of the fallback by design, so a mock
+/// declaring one of these paths loads fine, is reported by `/admin/mocks`, and
+/// then never serves a request. Naming the reservations makes that sayable —
+/// at load time, and on the dashboard — and makes them movable, for anyone
+/// whose API genuinely owns `/health` or `/admin/...`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReservedRoutes {
+    /// Where the health check is served, or `None` when it is switched off.
+    pub health: Option<String>,
+    /// The prefix the admin API is mounted under, or `None` when it is
+    /// switched off. Never has a trailing slash.
+    pub admin_prefix: Option<String>,
+}
+
+impl Default for ReservedRoutes {
+    fn default() -> Self {
+        Self {
+            health: Some(DEFAULT_HEALTH_PATH.to_string()),
+            admin_prefix: Some(DEFAULT_ADMIN_PREFIX.to_string()),
+        }
+    }
+}
+
+impl ReservedRoutes {
+    /// Read the configuration from the environment.
+    ///
+    /// Both knobs default to today's behavior, so an existing deployment that
+    /// sets neither is routed exactly as it was.
+    pub fn from_env() -> Self {
+        Self::from_values(
+            std::env::var(HEALTH_PATH_ENV).ok(),
+            std::env::var(ADMIN_PREFIX_ENV).ok(),
+            std::env::var(DISABLE_ADMIN_ENV).ok(),
+        )
+    }
+
+    /// [`ReservedRoutes::from_env`] with the environment injected, so the
+    /// rules are testable without mutating variables other tests share.
+    pub fn from_values(
+        health_path: Option<String>,
+        admin_prefix: Option<String>,
+        disable_admin: Option<String>,
+    ) -> Self {
+        let health = match health_path {
+            // An explicitly empty value is the way to say "don't serve it".
+            Some(raw) => normalize_route(&raw, HEALTH_PATH_ENV),
+            None => Some(DEFAULT_HEALTH_PATH.to_string()),
+        };
+
+        let admin = if disable_admin.as_deref().is_some_and(is_truthy) {
+            None
+        } else {
+            match admin_prefix {
+                Some(raw) => normalize_route(&raw, ADMIN_PREFIX_ENV),
+                None => Some(DEFAULT_ADMIN_PREFIX.to_string()),
+            }
+        };
+
+        Self {
+            health,
+            admin_prefix: admin,
+        }
+    }
+
+    /// Why a mock for `method path` would never be served, or `None` if it
+    /// would.
+    ///
+    /// Deliberately narrow: only the exact method+path pairs Mimic answers are
+    /// reserved. `POST /health` and `GET /admin/users` reach the fallback and
+    /// are perfectly good mocks.
+    pub fn reservation_for(&self, method: &str, path: &str) -> Option<&'static str> {
+        if self
+            .health
+            .as_deref()
+            .is_some_and(|health| health == path && method.eq_ignore_ascii_case("GET"))
+        {
+            return Some("Mimic's health check");
+        }
+
+        let prefix = self.admin_prefix.as_deref()?;
+        let suffix = path.strip_prefix(prefix)?;
+        ADMIN_ROUTES
+            .iter()
+            .find(|(route, methods)| {
+                *route == suffix
+                    && methods
+                        .iter()
+                        .any(|allowed| method.eq_ignore_ascii_case(allowed))
+            })
+            .map(|_| "Mimic's admin API")
+    }
+}
+
+/// Normalize a configured route path: trimmed, with a leading slash and no
+/// trailing one. An empty value means "switched off"; anything unusable falls
+/// back to off rather than panicking `Router::route`.
+fn normalize_route(raw: &str, var: &str) -> Option<String> {
+    let trimmed = raw.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return None;
+    }
+    if !trimmed.starts_with('/') {
+        warn!(
+            "Invalid {}='{}': a route must start with '/'. Using '/{}'.",
+            var, raw, trimmed
+        );
+        return Some(format!("/{}", trimmed));
+    }
+    Some(trimmed.to_string())
+}
+
 #[derive(Clone)]
 pub struct AppState {
     pub mocks: MockStore,
@@ -41,6 +188,10 @@ pub struct AppState {
     /// Which scenario tags are active, or `None` for "no filter" — the
     /// default. Read on every request, rewritten by `POST /admin/scenario`.
     pub active_tags: ActiveTags,
+    /// The method+path pairs Mimic answers itself. Shared with the router that
+    /// registered them so `/admin/mocks` can mark a shadowed mock unreachable
+    /// instead of leaving it at an unexplained `hits: 0`.
+    pub reserved: Arc<ReservedRoutes>,
 }
 
 impl AppState {
@@ -63,7 +214,16 @@ impl AppState {
             mock_hits: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             started_at: std::time::Instant::now(),
             active_tags: Arc::new(tokio::sync::RwLock::new(active_tags)),
+            reserved: Arc::new(ReservedRoutes::default()),
         }
+    }
+
+    /// Replace the reserved-route configuration, as `main` does once it has
+    /// read the environment. Defaults to `/health` + `/admin`, which is what
+    /// every test — and every deployment that configures neither — wants.
+    pub fn with_reserved(mut self, reserved: ReservedRoutes) -> Self {
+        self.reserved = Arc::new(reserved);
+        self
     }
 }
 
@@ -696,7 +856,13 @@ fn describe_mock_entry(
     mock: &MockConfig,
     hits: u64,
     active_tags: Option<&HashSet<String>>,
+    reserved: &ReservedRoutes,
 ) -> serde_json::Value {
+    // A mock on a reserved path is loaded, listed, and never served — the one
+    // miss the dashboard couldn't previously see, because the request never
+    // reaches `handle_request` and so is never recorded.
+    let shadowed_by = reserved.reservation_for(&mock.method, &mock.path);
+
     json!({
         "key": key,
         "index": index,
@@ -720,6 +886,16 @@ fn describe_mock_entry(
         // which is otherwise indistinguishable from a broken matcher.
         "tags": mock.tags,
         "active": mock.is_active(active_tags),
+        // Whether a request can reach this mock at all, and why not when it
+        // can't. `hits: 0` on a reachable mock means "nothing asked for it";
+        // on an unreachable one it means "nothing ever can".
+        "reachable": shadowed_by.is_none(),
+        "unreachable_reason": shadowed_by.map(|owner| {
+            format!(
+                "{} {} is reserved by {} and will never be served from a mock",
+                mock.method, mock.path, owner
+            )
+        }),
         // The whole config, so the dashboard's expand-a-row can show what the
         // file says without a second round trip
         "config": mock,
@@ -752,6 +928,7 @@ pub async fn list_mocks(State(state): State<AppState>) -> Json<serde_json::Value
                 mock,
                 hit_count,
                 active_tags.as_ref(),
+                &state.reserved,
             ));
         }
     }
@@ -4512,5 +4689,152 @@ mod scenario_tests {
         if let Some(value) = restore {
             std::env::set_var(ACTIVE_TAGS_ENV, value);
         }
+    }
+
+    // ── Reserved routes (#87) ───────────────────────────────────────────
+
+    fn reserved(
+        health: Option<&str>,
+        admin: Option<&str>,
+        disable: Option<&str>,
+    ) -> ReservedRoutes {
+        ReservedRoutes::from_values(
+            health.map(str::to_string),
+            admin.map(str::to_string),
+            disable.map(str::to_string),
+        )
+    }
+
+    #[test]
+    fn unset_variables_reserve_exactly_what_mimic_has_always_reserved() {
+        assert_eq!(reserved(None, None, None), ReservedRoutes::default());
+        assert_eq!(
+            ReservedRoutes::default().health.as_deref(),
+            Some(DEFAULT_HEALTH_PATH)
+        );
+        assert_eq!(
+            ReservedRoutes::default().admin_prefix.as_deref(),
+            Some(DEFAULT_ADMIN_PREFIX)
+        );
+    }
+
+    #[test]
+    fn only_the_exact_pairs_mimic_answers_are_reserved() {
+        let routes = ReservedRoutes::default();
+
+        assert!(routes.reservation_for("GET", "/health").is_some());
+        assert!(routes.reservation_for("GET", "/admin/mocks").is_some());
+        assert!(routes.reservation_for("POST", "/admin/scenario").is_some());
+        assert!(routes
+            .reservation_for("DELETE", "/admin/requests")
+            .is_some());
+
+        // These reach the fallback and are perfectly good mocks; warning about
+        // them would be noise, and marking them unreachable would be a lie.
+        assert_eq!(routes.reservation_for("POST", "/health"), None);
+        assert_eq!(routes.reservation_for("POST", "/admin/mocks"), None);
+        assert_eq!(routes.reservation_for("GET", "/admin/users"), None);
+        assert_eq!(routes.reservation_for("GET", "/healthz"), None);
+    }
+
+    #[test]
+    fn method_comparison_is_case_insensitive() {
+        let routes = ReservedRoutes::default();
+        assert!(routes.reservation_for("get", "/health").is_some());
+    }
+
+    #[test]
+    fn an_empty_value_switches_a_route_off() {
+        let routes = reserved(Some(""), None, None);
+        assert_eq!(routes.health, None);
+        assert_eq!(
+            routes.reservation_for("GET", "/health"),
+            None,
+            "with the health check gone, the path is a mock's to claim"
+        );
+    }
+
+    #[test]
+    fn the_admin_api_can_be_moved_or_switched_off() {
+        let moved = reserved(None, Some("/_mimic"), None);
+        assert!(moved.reservation_for("GET", "/_mimic/mocks").is_some());
+        assert_eq!(moved.reservation_for("GET", "/admin/mocks"), None);
+
+        for truthy in ["true", "1", "yes", "on", " TRUE "] {
+            let off = reserved(None, None, Some(truthy));
+            assert_eq!(off.admin_prefix, None, "MIMIC_DISABLE_ADMIN={}", truthy);
+            assert_eq!(off.reservation_for("GET", "/admin/mocks"), None);
+        }
+
+        // A non-affirmative value leaves the admin API where it is, rather
+        // than treating "any value at all" as "off".
+        assert_eq!(
+            reserved(None, None, Some("false")).admin_prefix.as_deref(),
+            Some(DEFAULT_ADMIN_PREFIX)
+        );
+    }
+
+    #[test]
+    fn a_prefix_is_normalized_so_it_can_never_panic_the_router() {
+        // `Router::route` panics on a path without a leading slash, and a
+        // trailing slash would produce "/ops//mocks".
+        assert_eq!(
+            reserved(None, Some("  /ops/  "), None)
+                .admin_prefix
+                .as_deref(),
+            Some("/ops")
+        );
+        assert_eq!(
+            reserved(None, Some("ops"), None).admin_prefix.as_deref(),
+            Some("/ops")
+        );
+        assert_eq!(reserved(None, Some("/"), None).admin_prefix, None);
+    }
+
+    #[test]
+    fn disable_wins_over_a_configured_prefix() {
+        assert_eq!(
+            reserved(None, Some("/ops"), Some("true")).admin_prefix,
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_mocks_marks_a_shadowed_mock_unreachable() {
+        // The reported case: a mock for GET /health loads, is listed, and can
+        // never serve. `hits: 0` alone doesn't say which of those it is.
+        let state = state_with(
+            vec![
+                mock("GET", "/health", "health-down", &[]),
+                mock("GET", "/users", "users", &[]),
+            ],
+            None,
+        );
+
+        let Json(body) = list_mocks(State(state)).await;
+        let entries = body["mocks"].as_array().unwrap();
+
+        let health = entries
+            .iter()
+            .find(|e| e["path"] == "/health")
+            .expect("the shadowed mock is still listed");
+        assert_eq!(health["reachable"], false);
+        assert!(health["unreachable_reason"]
+            .as_str()
+            .unwrap()
+            .contains("reserved by"));
+
+        let users = entries.iter().find(|e| e["path"] == "/users").unwrap();
+        assert_eq!(users["reachable"], true);
+        assert_eq!(users["unreachable_reason"], serde_json::Value::Null);
+    }
+
+    #[tokio::test]
+    async fn a_mock_is_reachable_once_the_route_it_collided_with_is_freed() {
+        let state = state_with(vec![mock("GET", "/health", "health-down", &[])], None)
+            .with_reserved(reserved(Some(""), None, None));
+
+        let Json(body) = list_mocks(State(state)).await;
+        assert_eq!(body["mocks"][0]["reachable"], true);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,10 @@ async fn run_server() {
     // Scenario selection: which tagged mock groups start out matchable
     let active_tags = configured_active_tags();
 
+    // Which method+path pairs Mimic answers itself, and therefore can't serve
+    // from a mock.
+    let reserved = handler::ReservedRoutes::from_env();
+
     info!("Configuration:");
     info!(
         "  Mocks directory: {} ({})",
@@ -137,19 +141,33 @@ async fn run_server() {
         0 => info!("  Request log: unbounded"),
         n => info!("  Request log: last {} request(s)", n),
     }
+    info!(
+        "  Health check: {}",
+        reserved.health.as_deref().unwrap_or("(disabled)")
+    );
+    info!(
+        "  Admin API: {}",
+        reserved
+            .admin_prefix
+            .as_deref()
+            .map_or("(disabled)".to_string(), |prefix| format!("{}/*", prefix))
+    );
 
     // Load mock configurations
     let mocks = load_mocks(&mocks_dir.path);
-    {
+    let mut shadowed = {
         let m = mocks.read().await;
         info!("Loaded {} mock(s)", m.len());
         if m.is_empty() {
             warn_empty_mock_set(&mocks_dir);
         }
-    }
+        let shadowed = shadowed_mocks(&m, &reserved);
+        warn_about_shadowed_mocks(&shadowed);
+        shadowed
+    };
 
     // Create application state
-    let state = AppState::with_active_tags(mocks.clone(), active_tags);
+    let state = AppState::with_active_tags(mocks.clone(), active_tags).with_reserved(reserved);
 
     // Spawn background task for hot-reloading mock files
     const RELOAD_INTERVAL_SECS: u64 = 2;
@@ -160,6 +178,7 @@ async fn run_server() {
     // Per-mock state the reloader has to reconcile against the new mock set.
     let reload_counters = state.sequence_counters.clone();
     let reload_hits = state.mock_hits.clone();
+    let reload_reserved = state.reserved.clone();
     tokio::spawn(async move {
         let mut interval =
             tokio::time::interval(std::time::Duration::from_secs(RELOAD_INTERVAL_SECS));
@@ -198,6 +217,14 @@ async fn run_server() {
                         new_len
                     );
                 }
+                // Warn only when the set changes: this loop runs every two
+                // seconds, and a collision that has already been reported does
+                // not need reporting 30 times a minute.
+                let current = shadowed_mocks(&store, &reload_reserved);
+                if current != shadowed {
+                    warn_about_shadowed_mocks(&current);
+                    shadowed = current;
+                }
                 live_identities(&store)
             };
 
@@ -224,6 +251,62 @@ async fn run_server() {
     axum::serve(listener, app).await.unwrap_or_else(|e| {
         panic!("Server error: {}", e);
     });
+}
+
+/// One mock that will never serve a request because Mimic answers its
+/// method+path itself: the file it came from, and what claims the route.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ShadowedMock {
+    method: String,
+    path: String,
+    source: String,
+    owner: &'static str,
+}
+
+/// Every loaded mock a reserved route shadows, sorted so the set can be
+/// compared between reloads.
+fn shadowed_mocks(
+    store: &HashMap<String, Vec<types::MockConfig>>,
+    reserved: &handler::ReservedRoutes,
+) -> Vec<ShadowedMock> {
+    let mut found: Vec<ShadowedMock> = store
+        .values()
+        .flatten()
+        .filter_map(|mock| {
+            reserved
+                .reservation_for(&mock.method, &mock.path)
+                .map(|owner| ShadowedMock {
+                    method: mock.method.clone(),
+                    path: mock.path.clone(),
+                    source: mock
+                        .source
+                        .clone()
+                        .unwrap_or_else(|| "(built in-process)".to_string()),
+                    owner,
+                })
+        })
+        .collect();
+    found.sort();
+    found
+}
+
+/// Say out loud that a mock is loaded and unreachable.
+///
+/// Explicit routes are matched ahead of the fallback by design, so such a mock
+/// parses, registers, is listed by `/admin/mocks`, and then sits at `hits: 0`
+/// forever. Nothing else in the system can report it: the request never
+/// reaches `handle_request`, so it is never recorded, and the dashboard —
+/// whose whole premise is reading *why* a request didn't match — is blind to
+/// precisely this one.
+fn warn_about_shadowed_mocks(shadowed: &[ShadowedMock]) {
+    for mock in shadowed {
+        warn!(
+            "{} declares {} {}, which is reserved by {} and will never be served. \
+             Move it, or free the route (see MIMIC_HEALTH_PATH / MIMIC_ADMIN_PREFIX / \
+             MIMIC_DISABLE_ADMIN).",
+            mock.source, mock.method, mock.path, mock.owner
+        );
+    }
 }
 
 /// Every mock identity a mock map currently registers.
@@ -339,18 +422,59 @@ fn apply_reload(
     merged
 }
 
+/// Build the HTTP router.
+///
+/// Every built-in route carries `.fallback(handle_request)`: a method the
+/// route doesn't declare — `POST /health`, `PUT /admin/requests` — used to get
+/// a bare `405 Method Not Allowed` from axum's method router, a response shape
+/// Mimic doesn't document and never records in the request log. Those requests
+/// now reach the normal pipeline, so they can be mocked, and are answered with
+/// the documented `mock not found` body when they aren't.
+///
+/// Which routes exist at all comes from `state.reserved`, so `MIMIC_HEALTH_PATH`
+/// and `MIMIC_ADMIN_PREFIX` / `MIMIC_DISABLE_ADMIN` can hand these paths back
+/// to an API that genuinely owns them.
 fn create_router(state: AppState) -> Router {
-    Router::new()
-        // Health check endpoint
-        .route("/health", get(health_check))
-        // Admin dashboard and request history API
-        .route("/admin/dashboard", get(admin_dashboard))
-        .route("/admin/requests", get(list_requests).delete(clear_requests))
-        .route("/admin/mocks", get(list_mocks))
-        .route("/admin/sequences", get(list_sequences))
-        .route("/admin/sequences/reset", post(reset_sequences))
-        // Scenario switching: which tagged mock groups are currently matchable
-        .route("/admin/scenario", get(get_scenario).post(set_scenario))
+    let reserved = state.reserved.clone();
+    let mut router = Router::new();
+
+    if let Some(health_path) = reserved.health.as_deref() {
+        router = router.route(health_path, get(health_check).fallback(handle_request));
+    }
+
+    if let Some(prefix) = reserved.admin_prefix.as_deref() {
+        let at = |suffix: &str| format!("{}{}", prefix, suffix);
+        router = router
+            // Admin dashboard and request history API
+            .route(
+                &at("/dashboard"),
+                get(admin_dashboard).fallback(handle_request),
+            )
+            .route(
+                &at("/requests"),
+                get(list_requests)
+                    .delete(clear_requests)
+                    .fallback(handle_request),
+            )
+            .route(&at("/mocks"), get(list_mocks).fallback(handle_request))
+            .route(
+                &at("/sequences"),
+                get(list_sequences).fallback(handle_request),
+            )
+            .route(
+                &at("/sequences/reset"),
+                post(reset_sequences).fallback(handle_request),
+            )
+            // Scenario switching: which tagged mock groups are currently matchable
+            .route(
+                &at("/scenario"),
+                get(get_scenario)
+                    .post(set_scenario)
+                    .fallback(handle_request),
+            );
+    }
+
+    router
         // Catch-all route for mock requests
         .fallback(any(handle_request))
         // Add state
@@ -586,6 +710,143 @@ mod tests {
         let bytes = response.into_body().collect().await.unwrap().to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(json["reset"], 0);
+    }
+
+    // ------------------------------------------------------------------
+    // Reserved routes (#87)
+    // ------------------------------------------------------------------
+
+    fn state_serving(mocks: Vec<MockConfig>) -> AppState {
+        AppState::new(Arc::new(tokio::sync::RwLock::new(map(mocks))))
+    }
+
+    async fn call(app: Router, method: &str, uri: &str) -> (StatusCode, Vec<u8>) {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(method)
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        (status, bytes.to_vec())
+    }
+
+    #[tokio::test]
+    async fn test_unsupported_method_on_a_reserved_path_is_not_a_bare_405() {
+        // axum's method router answered `POST /health` with an empty 405 —
+        // a shape Mimic doesn't document and never records.
+        let app = create_router(test_state());
+        let (status, body) = call(app, "POST", "/health").await;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "mock not found");
+        assert_eq!(json["path"], "/health");
+    }
+
+    #[tokio::test]
+    async fn test_a_method_the_admin_api_does_not_declare_reaches_the_mock_handler() {
+        let app = create_router(state_serving(vec![mock("PUT", "/admin/requests", "mine")]));
+        let (status, body) = call(app, "PUT", "/admin/requests").await;
+
+        assert_eq!(status, StatusCode::OK);
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["source"], "mine");
+    }
+
+    #[tokio::test]
+    async fn test_a_mock_cannot_shadow_the_health_check_by_default() {
+        // The behavior this issue documents rather than changes: /health stays
+        // Mimic's until someone frees it. The loader warning and the
+        // `reachable: false` flag on /admin/mocks are what make it visible.
+        let app = create_router(state_serving(vec![mock("GET", "/health", "mine")]));
+        let (status, body) = call(app, "GET", "/health").await;
+
+        assert_eq!(status, StatusCode::OK);
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["status"], "healthy");
+    }
+
+    #[tokio::test]
+    async fn test_freeing_the_health_path_lets_a_mock_serve_it() {
+        let state = state_serving(vec![mock("GET", "/health", "mine")]).with_reserved(
+            handler::ReservedRoutes {
+                health: None,
+                admin_prefix: Some("/admin".to_string()),
+            },
+        );
+        let (status, body) = call(create_router(state), "GET", "/health").await;
+
+        assert_eq!(status, StatusCode::OK);
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["source"], "mine", "the mock should win now");
+    }
+
+    #[tokio::test]
+    async fn test_moving_the_admin_prefix_moves_every_admin_route() {
+        let state = state_serving(vec![mock("GET", "/admin/mocks", "mine")]).with_reserved(
+            handler::ReservedRoutes {
+                health: Some("/health".to_string()),
+                admin_prefix: Some("/_mimic".to_string()),
+            },
+        );
+        let app = create_router(state.clone());
+
+        let (status, body) = call(app, "GET", "/_mimic/mocks").await;
+        assert_eq!(status, StatusCode::OK);
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["mocks"].is_array(), "the admin API moved here");
+
+        // …and the old prefix is now the mock set's to use.
+        let (status, body) = call(create_router(state), "GET", "/admin/mocks").await;
+        assert_eq!(status, StatusCode::OK);
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["source"], "mine");
+    }
+
+    #[tokio::test]
+    async fn test_disabling_the_admin_api_removes_all_of_its_routes() {
+        let state = state_serving(vec![]).with_reserved(handler::ReservedRoutes {
+            health: Some("/health".to_string()),
+            admin_prefix: None,
+        });
+        let (status, body) = call(create_router(state), "GET", "/admin/requests").await;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "mock not found");
+    }
+
+    #[test]
+    fn test_shadowed_mocks_names_the_file_and_what_claims_the_route() {
+        let mut health = mock("GET", "/health", "down");
+        health.source = Some("mocks/health_down.json".to_string());
+        let store = map(vec![health, mock("GET", "/users", "users")]);
+
+        let found = shadowed_mocks(&store, &handler::ReservedRoutes::default());
+
+        assert_eq!(found.len(), 1, "only the reserved path collides");
+        assert_eq!(found[0].path, "/health");
+        assert_eq!(found[0].source, "mocks/health_down.json");
+    }
+
+    #[test]
+    fn test_nothing_is_shadowed_once_the_routes_are_freed() {
+        let store = map(vec![
+            mock("GET", "/health", "down"),
+            mock("GET", "/admin/mocks", "mine"),
+        ]);
+        let freed = handler::ReservedRoutes {
+            health: None,
+            admin_prefix: None,
+        };
+
+        assert!(shadowed_mocks(&store, &freed).is_empty());
     }
 
     // ------------------------------------------------------------------

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -75,6 +75,7 @@ tbody td{padding:.55rem 1rem;font-size:.83rem;vertical-align:top}
 .auto-refresh input[type=checkbox]{accent-color:var(--accent)}
 .badge{display:inline-block;font-size:.68rem;font-weight:600;padding:.05rem .4rem;border-radius:4px;background:var(--raised);color:var(--muted);border:1px solid var(--border);margin-right:.25rem}
 .badge-on{background:rgba(108,99,255,.15);color:var(--accent);border-color:transparent}
+.badge-warn{background:rgba(230,150,40,.18);color:#e69628;border-color:transparent}
 .new-banner{display:none;margin-bottom:.75rem;padding:.45rem .9rem;border-radius:6px;background:var(--accent);color:#fff;font-size:.82rem;cursor:pointer;border:none;font-family:inherit;font-weight:500}
 .new-banner.visible{display:block}
 .paused-note{font-size:.75rem;color:var(--muted);margin-left:.5rem}
@@ -573,6 +574,15 @@ tbody td{padding:.55rem 1rem;font-size:.83rem;vertical-align:top}
     return ' ' + html;
   }
 
+  // A mock on a route Mimic answers itself never reaches the matcher, so it
+  // has no entry in the request log to explain its permanent zero hits. This
+  // badge is the only place that can say so.
+  function unreachableBadge(m){
+    if(m.reachable !== false) return '';
+    var why = m.unreachable_reason || 'this route is reserved by Mimic';
+    return ' <span class="badge badge-warn" title="'+escapeHtml(why)+'">unreachable</span>';
+  }
+
   function renderMocks(){
     var needle = qs('mock-search').value.trim().toLowerCase();
     var list = mocksCache.filter(function(m){
@@ -600,7 +610,7 @@ tbody td{padding:.55rem 1rem;font-size:.83rem;vertical-align:top}
       var source = m.source ? '<span class="mono">'+escapeHtml(m.source)+'</span>' : dash();
       html += '<tbody data-mock="'+i+'"><tr>'
         + '<td><span class="'+methodClass(m.method)+'">'+escapeHtml(m.method)+'</span></td>'
-        + '<td class="path-cell">'+escapeHtml(m.path)+tagBadges(m)+'</td>'
+        + '<td class="path-cell">'+escapeHtml(m.path)+tagBadges(m)+unreachableBadge(m)+'</td>'
         + '<td><span class="status '+statusClass(m.status)+'">'+m.status+'</span></td>'
         + '<td>'+matcherBadges(m)+'</td>'
         + '<td>'+escapeHtml(delay)+'</td>'


### PR DESCRIPTION
**Stack 5/6** — based on #95. Review the [top commit only](https://github.com/ragilhadi/mimic/pull/96/commits).

---

`create_router` registers `/health` and the `/admin/*` endpoints before `.fallback(any(handle_request))`, and explicit routes are matched ahead of the fallback by design. A mock declaring one of those paths therefore loads fine, is reported by `GET /admin/mocks`, and **never serves a single request** — sitting at `hits: 0` forever with nothing anywhere to explain it.

Nothing else in the system could report it: the request never reaches `handle_request`, so it is never recorded, and the dashboard — whose whole premise is reading *why* a request didn't match — was blind to precisely this one.

`/health` is not an exotic thing to want to mock. It's the single most common endpoint in any service Mimic stands in for (k8s probes, Actuator, ELB), and "how does my client react to a backend reporting `503 {"status":"down"}`" was simply not expressible.

## Three changes, none of which alter default routing

**Say it.** `ReservedRoutes` is the one list of method+path pairs Mimic answers itself. The router registers *from* it and the diagnostics check *against* it, so a route can't be reserved in the warning and unregistered in the router, or the reverse. The loader warns at startup — and again when hot reload introduces a collision, but only when the set *changes*, since that loop runs every two seconds — naming the file:

```
WARN mimic: mocks/health_down.json declares GET /health, which is reserved by Mimic's
            health check and will never be served. Move it, or free the route …
```

`/admin/mocks` reports `"reachable": false` with an `unreachable_reason`, and the dashboard renders an **unreachable** badge — so a permanent zero is distinguishable from "nothing has called it yet".

**Scope it.** Only the exact method+path pairs Mimic answers are reserved. `POST /health` and `GET /admin/users` are ordinary mock paths, neither warned about nor flagged.

**Free it.**

```bash
MIMIC_HEALTH_PATH= mimic                 # no health check; GET /health is yours
MIMIC_HEALTH_PATH=/_mimic/health mimic   # or move it
MIMIC_ADMIN_PREFIX=/_mimic mimic         # admin API elsewhere
MIMIC_DISABLE_ADMIN=true mimic           # no admin API at all
```

All three default to today's behavior. Prefixes are normalized (leading slash added, trailing stripped) because `Router::route` **panics** on a malformed path — a config typo must not take the server down.

## The bare 405

Every built-in route gains `.fallback(handle_request)`. `POST /health` used to get an empty `405 Method Not Allowed` from axum's method router — a shape Mimic doesn't document and doesn't record. Those requests now go through the normal pipeline: mockable, and answered with the documented `mock not found` body when they aren't.

## Tests

Router-level (through `create_router`): no more bare 405; an undeclared method reaches a mock; `/health` still wins by default; freeing it lets a mock serve it; moving the prefix moves *every* admin route and hands the old one back to the mock set; disabling removes them all. Unit-level: defaults unchanged, exactness of the reservation, case-insensitive methods, empty-means-off, prefix normalization, disable-wins-over-prefix, and `/admin/mocks` marking.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)